### PR TITLE
Joren

### DIFF
--- a/resources/js/game_list.js
+++ b/resources/js/game_list.js
@@ -66,7 +66,7 @@ export default class GameList extends React.Component {
 			.then(resp => resp.json())
 			.then(js => {
 				let games = js.Properties;
-				if (!this.props.skipMore) {
+				if (!this.props.contained) {
 					this.moreLink = js.Links.find(l => {
 						return l.Rel == "next";
 					});
@@ -83,6 +83,17 @@ export default class GameList extends React.Component {
 					},
 					_ => {
 						this.loading = false;
+						if (
+							this.state.games.length > 0 &&
+							this.props.onFilled
+						) {
+							this.props.onFilled();
+						} else if (
+							this.state.games.length == 0 &&
+							this.props.onEmpty
+						) {
+							this.props.onEmpty();
+						}
 					}
 				);
 			});
@@ -96,7 +107,7 @@ export default class GameList extends React.Component {
 						width: "100%",
 						textAlign: "center",
 						paddingTop: "calc(50% - 20px)",
-						paddingBottom: "calc(50% - 20px)",
+						paddingBottom: "calc(50% - 20px)"
 					}}
 				>
 					<MaterialUI.CircularProgress />
@@ -105,7 +116,10 @@ export default class GameList extends React.Component {
 		} else {
 			return (
 				<GameListElement
-					summaryOnly={this.props.contained}
+					onPhaseMessage={this.props.onPhaseMessage}
+					summaryOnly={
+						this.props.contained && !this.props.withDetails
+					}
 					game={el}
 					key={el.Properties.ID}
 				/>

--- a/resources/js/game_list.js
+++ b/resources/js/game_list.js
@@ -94,7 +94,9 @@ export default class GameList extends React.Component {
 					key="progress"
 					style={{
 						width: "100%",
-						textAlign: "center"
+						textAlign: "center",
+						paddingTop: "calc(50% - 20px)",
+						paddingBottom: "calc(50% - 20px)",
 					}}
 				>
 					<MaterialUI.CircularProgress />

--- a/resources/js/game_list_element.js
+++ b/resources/js/game_list_element.js
@@ -69,7 +69,11 @@ export default class GameListElement extends React.Component {
 		if (payload.data.gameID != this.state.game.Properties.ID) {
 			return false;
 		}
-		this.reloadGame();
+		if (this.props.onPhaseMessage) {
+			this.props.onPhaseMessage();
+		} else {
+			this.reloadGame();
+		}
 		return false;
 	}
 	componentWillUnmount() {
@@ -802,7 +806,7 @@ export default class GameListElement extends React.Component {
 					key="requirement-notice"
 					className={noticeClass}
 				>
-					You can't join this game because: {" "}
+					You can't join this game because:{" "}
 					{this.state.game.Properties.FailedRequirements.join(", ")}.
 				</MaterialUI.Typography>
 			);
@@ -842,8 +846,10 @@ export default class GameListElement extends React.Component {
 							key="deadline-warning"
 							className={warningClass}
 						>
-							WARNING: This game has short deadlines (less than 12 hours). 
-							If it starts while you're unavailable, you might miss parts of the game greatly impacting your reliability score.
+							WARNING: This game has short deadlines (less than 12
+							hours). If it starts while you're unavailable, you
+							might miss parts of the game greatly impacting your
+							reliability score.
 						</MaterialUI.Typography>
 					);
 				}
@@ -856,8 +862,10 @@ export default class GameListElement extends React.Component {
 							key="reliability-warning"
 							className={warningClass}
 						>
-							WARNING: We advise you to join a different game, because you have high reliability. 
-							Since this game has no reliability requirements, it might have (some) absent players. 
+							WARNING: We advise you to join a different game,
+							because you have high reliability. Since this game
+							has no reliability requirements, it might have
+							(some) absent players.
 						</MaterialUI.Typography>
 					);
 				}

--- a/resources/js/game_list_element.js
+++ b/resources/js/game_list_element.js
@@ -13,1313 +13,1230 @@ flex-direction: row;
 justify-content: space-between;
 flex-wrap: wrap;`);
 const secondRowSummaryColorClass = helpers.scopedClass(
-	"color: rgba(40, 26, 26, 0.7);"
+  "color: rgba(40, 26, 26, 0.7);"
 );
 const summaryIconsAndPhaseClass = helpers.scopedClass(
-	"display: flex; justify-content: right;"
+  "display: flex; justify-content: right;"
 );
 const summaryIconsClass = helpers.scopedClass("padding-right: 4px;");
 const sixteenBySixteenClass = helpers.scopedClass(
-	"height: 16px !important; width: 16px !important;"
+  "height: 16px !important; width: 16px !important;"
 );
 
+
 export default class GameListElement extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			game: this.props.game,
-			viewOpen: false,
-			expanded: false,
-			member: props.game.Properties.Members.find(e => {
-				return e.User.Email == Globals.user.Email;
-			})
-		};
-		this.variant = Globals.variants.find(v => {
-			return v.Properties.Name == this.props.game.Properties.Variant;
-		});
-		this.nationPreferencesDialog = null;
-		this.renameGameDialog = null;
-		this.valignClass = helpers.scopedClass(
-			"display: flex; align-items: center;"
-		);
-		this.viewGame = this.viewGame.bind(this);
-		this.closeGame = this.closeGame.bind(this);
-		this.getIcons = this.getIcons.bind(this);
-		this.joinGame = this.joinGame.bind(this);
-		this.leaveGame = this.leaveGame.bind(this);
-		this.renameGame = this.renameGame.bind(this);
-		this.joinGameWithPreferences = this.joinGameWithPreferences.bind(this);
-		this.reloadGame = this.reloadGame.bind(this);
-		this.phaseMessageHandler = this.phaseMessageHandler.bind(this);
-		this.messageHandler = this.messageHandler.bind(this);
-		// Dead means that we left this game when we were the only member, so it's gone.
-		this.dead = false;
-	}
-	renameGame() {
-		this.renameGameDialog.setState({ open: true });
-	}
-	messageHandler(payload) {
-		if (payload.data.message.GameID != this.props.game.Properties.ID) {
-			return false;
-		}
-		this.reloadGame();
-		return false;
-	}
-	phaseMessageHandler(payload) {
-		if (payload.data.gameID != this.state.game.Properties.ID) {
-			return false;
-		}
-		if (this.props.onPhaseMessage) {
-			this.props.onPhaseMessage();
-		} else {
-			this.reloadGame();
-		}
-		return false;
-	}
-	componentWillUnmount() {
-		Globals.messaging.unsubscribe("phase", this.phaseMessageHandler);
-		Globals.messaging.unsubscribe("message", this.messageHandler);
-	}
-	componentDidMount() {
-		Globals.messaging.subscribe("phase", this.phaseMessageHandler);
-		Globals.messaging.subscribe("message", this.messageHandler);
-	}
-	joinGameWithPreferences(link, preferences) {
-		helpers.incProgress();
-		helpers
-			.safeFetch(
-				helpers.createRequest(link.URL, {
-					method: link.Method,
-					headers: {
-						"Content-Type": "application/json"
-					},
-					body: JSON.stringify({
-						NationPreferences: preferences.join(",")
-					})
-				})
-			)
-			.then(_ => {
-				helpers.decProgress();
-				gtag("event", "game_list_element_join");
-				Globals.messaging.start();
-				this.setState(
-					(state, props) => {
-						state = Object.assign({}, state);
-						state.game.Links = state.game.Links.filter(l => {
-							return l.Rel != "join";
-						});
-						return state;
-					},
-					_ => {
-						this.reloadGame();
-					}
-				);
-			});
-	}
-	reloadGame() {
-		helpers
-			.safeFetch(
-				helpers.createRequest(
-					this.state.game.Links.find(l => {
-						return l.Rel == "self";
-					}).URL
-				)
-			)
-			.then(resp => resp.json())
-			.then(js => {
-				this.setState({
-					game: js,
-					member: js.Properties.Members.find(e => {
-						return e.User.Email == Globals.user.Email;
-					})
-				});
-			});
-	}
-	leaveGame(link) {
-		helpers.incProgress();
-		helpers
-			.safeFetch(
-				helpers.createRequest(link.URL, {
-					method: link.Method
-				})
-			)
-			.then(resp => resp.json())
-			.then(_ => {
-				helpers.decProgress();
-				gtag("event", "game_list_element_leave");
-				this.setState(
-					(state, props) => {
-						state = Object.assign({}, state);
-						state.game.Links = state.game.Links.filter(l => {
-							return l.Rel != "leave";
-						});
-						return state;
-					},
-					_ => {
-						if (this.state.game.Properties.Members.length > 1) {
-							this.reloadGame();
-						} else {
-							this.dead = true;
-							this.forceUpdate();
-						}
-					}
-				);
-			});
-	}
-	joinGame(link) {
-		if (this.state.game.Properties.NationAllocation == 1) {
-			this.nationPreferencesDialog.setState({
-				open: true,
-				nations: this.variant.Properties.Nations,
-				onSelected: preferences => {
-					this.joinGameWithPreferences(link, preferences);
-				}
-			});
-		} else {
-			this.joinGameWithPreferences(link, []);
-		}
-	}
-	closeGame() {
-		this.setState({ viewOpen: false });
-	}
-	viewGame(e) {
-		e.stopPropagation();
-		e.preventDefault();
-		this.setState({ viewOpen: true });
-	}
-	addIcon(ary, codepoint, color) {
-		ary.push(
-			helpers.createIcon(codepoint, {
-				padding: "4px 1px 0px 1px",
-				color: color,
-				fontSize: "14px"
-			})
-		);
-	}
-	getIcons() {
-		let itemKey = 0;
-		let icons = [];
-		if (
-			this.state.game.Properties.MinQuickness ||
-			this.state.game.Properties.MinReliability
-		) {
-			this.addIcon(icons, "\ue425", "black");
-		}
-		if (
-			this.state.game.Properties.MinRating ||
-			this.state.game.Properties.MaxRating
-		) {
-			this.addIcon(icons, "\ue83a", "black");
-		}
-		if (
-			this.state.game.Properties.MaxHater ||
-			this.state.game.Properties.MaxHated
-		) {
-			icons.push(
-				<MaterialUI.Tooltip
-					key={itemKey++}
-					disableFocusListener
-					title="Maximum hate requirement"
-				>
-					<MaterialUI.SvgIcon className={sixteenBySixteenClass}>
-						<g
-							id="Artboard"
-							stroke="none"
-							strokeWidth="1"
-							fill="none"
-							fillRule="evenodd"
-						>
-							<g
-								id="emoticon-angry-outline"
-								transform="translate(2.000000, 2.000000)"
-								fill="#000000"
-								fillRule="nonzero"
-							>
-								<path
-									d="M1.499,0.115 L19.2847763,17.8994949 L19.299,17.885 L19.8994949,18.4852814 L18.4852814,19.8994949 L16.3286725,17.7426435 C14.5506593,19.1960497 12.3167744,20 10,20 C7.3478351,20 4.80429597,18.9464316 2.92893219,17.0710678 C1.0535684,15.195704 0,12.6521649 0,10 C0,7.59864107 0.846427847,5.39497595 2.25721107,3.67107713 L0.100505063,1.51471863 L1.499,0.115 Z M3.68005389,5.09447025 C2.62704639,6.44913544 2,8.15134045 2,10 C2,14.418278 5.581722,18 10,18 C11.8486595,18 13.5508646,17.3729536 14.9055298,16.3199461 L13.293,14.707 L12.77,15.23 C12.32,14.5 11.25,14 10,14 C8.75,14 7.68,14.5 7.23,15.23 L5.81,13.81 C6.71,12.72 8.25,12 10,12 C10.2091413,12 10.4152832,12.0102834 10.6176919,12.0302527 L7.32314129,8.73840737 C7.08353442,8.90238797 6.7987395,9 6.5,9 C5.7,9 5,8.3 5,7.5 L5,6.414 L3.68005389,5.09447025 Z M10,0 C12.6521649,0 15.195704,1.0535684 17.0710678,2.92893219 C18.9464316,4.80429597 20,7.3478351 20,10 C20,11.6325537 19.6007944,13.2239482 18.8564416,14.6436748 L17.3584074,13.144315 C17.7713793,12.1791202 18,11.1162587 18,10 C18,7.87826808 17.1571453,5.84343678 15.6568542,4.34314575 C14.1565632,2.84285472 12.1217319,2 10,2 C8.88374129,2 7.82087979,2.22862069 6.85568497,2.64159261 L5.35539972,1.1417664 C6.74323813,0.41258719 8.32343661,0 10,0 Z M15,6 L15,7.5 C15,8.3 14.3,9 13.5,9 C12.7,9 12,8.3 12,7.5 L15,6 Z"
-									id="Combined-Shape"
-								></path>
-							</g>
-						</g>
-					</MaterialUI.SvgIcon>
-				</MaterialUI.Tooltip>
-			);
-		}
-		if (
-			this.state.game.Properties.DisableConferenceChat ||
-			this.state.game.Properties.DisableGroupChat ||
-			this.state.game.Properties.DisablePrivateChat
-		) {
-			icons.push(
-				<MaterialUI.Tooltip
-					key={itemKey++}
-					disableFocusListener
-					title="Chat disabled"
-				>
-					<MaterialUI.SvgIcon className={sixteenBySixteenClass}>
-						<g
-							id="Artboard"
-							stroke="none"
-							strokeWidth="1"
-							fill="none"
-							fillRule="evenodd"
-						>
-							<g id="message-24px">
-								<polygon
-									id="Path"
-									points="0 0 24 0 24 24 0 24"
-								></polygon>
-								<path
-									d="M2.4,2.614 L20.5847763,20.7989899 L20.598,20.784 L20.7989899,20.9842712 L19.3847763,22.3984848 L14.986,18 L6,18 L2,22 L2.008,5.022 L1,4.0137085 L2.4,2.614 Z M20,2 C21.05,2 21.9177686,2.82004132 21.9944872,3.85130541 L22,4 L22,16 C22,16.9134058 21.3794387,17.6889091 20.539101,17.925725 L16.614,14 L18,14 L18,12 L14.614,12 L13.614,11 L18,11 L18,9 L11.614,9 L10.614,8 L18,8 L18,6 L8.614,6 L4.614,2 L20,2 Z M8.987,12 L6,12 L6,14 L10.986,14 L8.987,12 Z M6,9.013 L6,11 L7.987,11 L6,9.013 Z"
-									id="Combined-Shape"
-									fill="#000000"
-									fillRule="nonzero"
-								></path>
-							</g>
-						</g>
-					</MaterialUI.SvgIcon>
-				</MaterialUI.Tooltip>
-			);
-		}
-		if (this.state.game.Properties.Private) {
-			this.addIcon(icons, "\ue897", "black");
-		}
-		if (this.state.game.Properties.NationAllocation == 1) {
-			this.addIcon(icons, "\ue065", "black");
-		}
-		return <MaterialUI.Box display="inline">{icons}</MaterialUI.Box>;
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      game: this.props.game,
+      viewOpen: false,
+      expanded: false,
+      member: props.game.Properties.Members.find((e) => {
+        return e.User.Email == Globals.user.Email;
+      }),
+    };
+    this.variant = Globals.variants.find((v) => {
+      return v.Properties.Name == this.props.game.Properties.Variant;
+    });
+    this.nationPreferencesDialog = null;
+    this.renameGameDialog = null;
+    this.valignClass = helpers.scopedClass(
+      "display: flex; align-items: center;"
+    );
+    this.viewGame = this.viewGame.bind(this);
+    this.closeGame = this.closeGame.bind(this);
+    this.getIcons = this.getIcons.bind(this);
+    this.joinGame = this.joinGame.bind(this);
+    this.leaveGame = this.leaveGame.bind(this);
+    this.renameGame = this.renameGame.bind(this);
+    this.joinGameWithPreferences = this.joinGameWithPreferences.bind(this);
+    this.reloadGame = this.reloadGame.bind(this);
+    this.phaseMessageHandler = this.phaseMessageHandler.bind(this);
+    this.messageHandler = this.messageHandler.bind(this);
+    // Dead means that we left this game when we were the only member, so it's gone.
+    this.dead = false;
+  }
 
-	render() {
-		let expandedGameCells = [];
-		expandedGameCells.push(
-			<div
-				style={{ width: "100%", display: "flex", alignItems: "center" }}
-			>
-				<MaterialUI.Icon style={{ marginRight: "8px" }}>
-					{helpers.createIcon("\ue55b")}
-				</MaterialUI.Icon>
-				<MaterialUI.Typography>
-					Game variant: {this.state.game.Properties.Variant}
-				</MaterialUI.Typography>
-			</div>
-		);
-		expandedGameCells.push(
-			<div
-				style={{ width: "100%", display: "flex", alignItems: "center" }}
-			>
-				<MaterialUI.Icon style={{ marginRight: "8px" }}>
-					{helpers.createIcon("\ue01b")}
-				</MaterialUI.Icon>
-				<MaterialUI.Typography>
-					Phase deadline{" "}
-					{helpers.minutesToDuration(
-						this.state.game.Properties.PhaseLengthMinutes
-					)}
-				</MaterialUI.Typography>
-			</div>
-		);
-		if (this.state.game.Properties.NonMovementPhaseLengthMinutes) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue01b")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Non movement phase deadline{" "}
-						{helpers.minutesToDuration(
-							this.state.game.Properties
-								.NonMovementPhaseLengthMinutes
-						)}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.LastYear) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue88b")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Ends after year: {this.state.game.Properties.LastYear}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		expandedGameCells.push(
-			<div
-				style={{ width: "100%", display: "flex", alignItems: "center" }}
-			>
-				<MaterialUI.Icon style={{ marginRight: "8px" }}>
-					<MaterialUI.SvgIcon>
-						<g
-							id="Artboard"
-							stroke="none"
-							strokeWidth="1"
-							fill="none"
-							fillRule="evenodd"
-						>
-							<g id="timelapse-24px">
-								<polygon
-									id="Path"
-									points="0 0 24 0 24 24 0 24"
-								></polygon>
-								<path
-									d="M12,6 C12.5719312,6 13.1251722,6.08002251 13.6491373,6.22948186 L12,12 Z M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M12,20 C7.58,20 4,16.42 4,12 C4,7.58 7.58,4 12,4 C16.42,4 20,7.58 20,12 C20,16.42 16.42,20 12,20 Z"
-									id="Shape"
-									fill="#000000"
-									fillRule="nonzero"
-								></path>
-							</g>
-						</g>
-					</MaterialUI.SvgIcon>
-				</MaterialUI.Icon>
-				<MaterialUI.Typography>
-					Created:{" "}
-					{helpers.timeStrToDate(
-						this.state.game.Properties.CreatedAt
-					)}{" "}
-				</MaterialUI.Typography>
-			</div>
-		);
-		if (this.state.game.Properties.Started) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue422")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Started:{" "}
-						{helpers.timeStrToDate(
-							this.state.game.Properties.StartedAt
-						)}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.Finished) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						<MaterialUI.SvgIcon>
-							<g
-								id="Artboard"
-								stroke="none"
-								strokeWidth="1"
-								fill="none"
-								fillRule="evenodd"
-							>
-								<g id="timelapse-24px">
-									<polygon
-										id="Path"
-										points="0 0 24 0 24 24 0 24"
-									></polygon>
-									<path
-										d="M12,6 C15.3137085,6 18,8.6862915 18,12 C18,15.3137085 15.3137085,18 12,18 C8.6862915,18 6,15.3137085 6,12 C6,9.25822274 7.83903025,6.94597402 10.3508627,6.22948186 L12,12 Z M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M12,20 C7.58,20 4,16.42 4,12 C4,7.58 7.58,4 12,4 C16.42,4 20,7.58 20,12 C20,16.42 16.42,20 12,20 Z"
-										id="Shape"
-										fill="#000000"
-										fillRule="nonzero"
-									></path>
-								</g>
-							</g>
-						</MaterialUI.SvgIcon>
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Finished:{" "}
-						{helpers.timeStrToDate(
-							this.state.game.Properties.FinishedAt
-						)}{" "}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		expandedGameCells.push(
-			<div
-				style={{ width: "100%", display: "flex", alignItems: "center" }}
-			>
-				{this.state.game.Properties.NationAllocation == 1 ? (
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue065")}
-					</MaterialUI.Icon>
-				) : (
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						<MaterialUI.SvgIcon>
-							<g
-								id="Artboard"
-								stroke="none"
-								strokeWidth="1"
-								fill="none"
-								fillRule="evenodd"
-							>
-								<g id="playlist_add_check-24px-(1)">
-									<rect
-										id="Rectangle"
-										x="0"
-										y="0"
-										width="24"
-										height="24"
-									></rect>
-									<path
-										d="M14,10 L2,10 L2,12 L14,12 L14,10 Z M14,6 L2,6 L2,8 L14,8 L14,6 Z M18.51,16.25 L21,18.75 L18.51,21.25 L18.51,19.5 L13,19.5 L13,18 L18.51,18 L18.51,16.25 Z M15.49,12 L15.49,13.75 L21,13.75 L21,15.25 L15.49,15.25 L15.49,17 L13,14.5 L15.49,12 Z M10,14 L10,16 L2,16 L2,14 L10,14 Z"
-										id="Shape"
-										fill="#000000"
-										fillRule="nonzero"
-									></path>
-								</g>
-								<g id="loop-24px">
-									<polygon
-										id="Path"
-										points="13 12 26 12 26 25 13 25"
-									></polygon>
-									<g id="transfer_within_a_station-24px">
-										<polygon
-											id="Path"
-											points="0 0 24 0 24 24 0 24"
-										></polygon>
-									</g>
-								</g>
-							</g>
-						</MaterialUI.SvgIcon>
-					</MaterialUI.Icon>
-				)}
+  renameGame() {
+    this.renameGameDialog.setState({ open: true });
+  }
+  messageHandler(payload) {
+    if (payload.data.message.GameID != this.props.game.Properties.ID) {
+      return false;
+    }
+    this.reloadGame();
+    return false;
+  }
+  phaseMessageHandler(payload) {
+    if (payload.data.gameID != this.state.game.Properties.ID) {
+      return false;
+    }
+    if (this.props.onPhaseMessage) {
+      this.props.onPhaseMessage();
+    } else {
+      this.reloadGame();
+    }
+    return false;
+  }
+  componentWillUnmount() {
+    Globals.messaging.unsubscribe("phase", this.phaseMessageHandler);
+    Globals.messaging.unsubscribe("message", this.messageHandler);
+  }
+  componentDidMount() {
+    Globals.messaging.subscribe("phase", this.phaseMessageHandler);
+    Globals.messaging.subscribe("message", this.messageHandler);
+  }
+  joinGameWithPreferences(link, preferences) {
+    helpers.incProgress();
+    helpers
+      .safeFetch(
+        helpers.createRequest(link.URL, {
+          method: link.Method,
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            NationPreferences: preferences.join(","),
+          }),
+        })
+      )
+      .then((_) => {
+        helpers.decProgress();
+        gtag("event", "game_list_element_join");
+        Globals.messaging.start();
+        this.setState(
+          (state, props) => {
+            state = Object.assign({}, state);
+            state.game.Links = state.game.Links.filter((l) => {
+              return l.Rel != "join";
+            });
+            return state;
+          },
+          (_) => {
+            this.reloadGame();
+          }
+        );
+      });
+  }
+  reloadGame() {
+    helpers
+      .safeFetch(
+        helpers.createRequest(
+          this.state.game.Links.find((l) => {
+            return l.Rel == "self";
+          }).URL
+        )
+      )
+      .then((resp) => resp.json())
+      .then((js) => {
+        this.setState({
+          game: js,
+          member: js.Properties.Members.find((e) => {
+            return e.User.Email == Globals.user.Email;
+          }),
+        });
+      });
+  }
+  leaveGame(link) {
+    helpers.incProgress();
+    helpers
+      .safeFetch(
+        helpers.createRequest(link.URL, {
+          method: link.Method,
+        })
+      )
+      .then((resp) => resp.json())
+      .then((_) => {
+        helpers.decProgress();
+        gtag("event", "game_list_element_leave");
+        this.setState(
+          (state, props) => {
+            state = Object.assign({}, state);
+            state.game.Links = state.game.Links.filter((l) => {
+              return l.Rel != "leave";
+            });
+            return state;
+          },
+          (_) => {
+            if (this.state.game.Properties.Members.length > 1) {
+              this.reloadGame();
+            } else {
+              this.dead = true;
+              this.forceUpdate();
+            }
+          }
+        );
+      });
+  }
+  joinGame(link) {
+    if (this.state.game.Properties.NationAllocation == 1) {
+      this.nationPreferencesDialog.setState({
+        open: true,
+        nations: this.variant.Properties.Nations,
+        onSelected: (preferences) => {
+          this.joinGameWithPreferences(link, preferences);
+        },
+      });
+    } else {
+      this.joinGameWithPreferences(link, []);
+    }
+  }
+  closeGame() {
+    this.setState({ viewOpen: false });
+  }
+  viewGame(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    this.setState({ viewOpen: true });
+  }
+  addIcon(ary, codepoint, color) {
+    ary.push(
+      helpers.createIcon(codepoint, {
+        padding: "4px 1px 0px 1px",
+        color: color,
+        fontSize: "14px",
+      })
+    );
+  }
+  getIcons() {
+    let itemKey = 0;
+    let icons = [];
+    if (
+      this.state.game.Properties.MinQuickness ||
+      this.state.game.Properties.MinReliability
+    ) {
+      this.addIcon(icons, "\ue425", "black");
+    }
+    if (
+      this.state.game.Properties.MinRating ||
+      this.state.game.Properties.MaxRating
+    ) {
+      this.addIcon(icons, "\ue83a", "black");
+    }
+    if (
+      this.state.game.Properties.MaxHater ||
+      this.state.game.Properties.MaxHated
+    ) {
+      icons.push(
+        <MaterialUI.Tooltip
+          key={itemKey++}
+          disableFocusListener
+          title="Maximum hate requirement"
+        >
+          <MaterialUI.SvgIcon className={sixteenBySixteenClass}>
+            <g
+              id="Artboard"
+              stroke="none"
+              strokeWidth="1"
+              fill="none"
+              fillRule="evenodd"
+            >
+              <g
+                id="emoticon-angry-outline"
+                transform="translate(2.000000, 2.000000)"
+                fill="#000000"
+                fillRule="nonzero"
+              >
+                <path
+                  d="M1.499,0.115 L19.2847763,17.8994949 L19.299,17.885 L19.8994949,18.4852814 L18.4852814,19.8994949 L16.3286725,17.7426435 C14.5506593,19.1960497 12.3167744,20 10,20 C7.3478351,20 4.80429597,18.9464316 2.92893219,17.0710678 C1.0535684,15.195704 0,12.6521649 0,10 C0,7.59864107 0.846427847,5.39497595 2.25721107,3.67107713 L0.100505063,1.51471863 L1.499,0.115 Z M3.68005389,5.09447025 C2.62704639,6.44913544 2,8.15134045 2,10 C2,14.418278 5.581722,18 10,18 C11.8486595,18 13.5508646,17.3729536 14.9055298,16.3199461 L13.293,14.707 L12.77,15.23 C12.32,14.5 11.25,14 10,14 C8.75,14 7.68,14.5 7.23,15.23 L5.81,13.81 C6.71,12.72 8.25,12 10,12 C10.2091413,12 10.4152832,12.0102834 10.6176919,12.0302527 L7.32314129,8.73840737 C7.08353442,8.90238797 6.7987395,9 6.5,9 C5.7,9 5,8.3 5,7.5 L5,6.414 L3.68005389,5.09447025 Z M10,0 C12.6521649,0 15.195704,1.0535684 17.0710678,2.92893219 C18.9464316,4.80429597 20,7.3478351 20,10 C20,11.6325537 19.6007944,13.2239482 18.8564416,14.6436748 L17.3584074,13.144315 C17.7713793,12.1791202 18,11.1162587 18,10 C18,7.87826808 17.1571453,5.84343678 15.6568542,4.34314575 C14.1565632,2.84285472 12.1217319,2 10,2 C8.88374129,2 7.82087979,2.22862069 6.85568497,2.64159261 L5.35539972,1.1417664 C6.74323813,0.41258719 8.32343661,0 10,0 Z M15,6 L15,7.5 C15,8.3 14.3,9 13.5,9 C12.7,9 12,8.3 12,7.5 L15,6 Z"
+                  id="Combined-Shape"
+                ></path>
+              </g>
+            </g>
+          </MaterialUI.SvgIcon>
+        </MaterialUI.Tooltip>
+      );
+    }
+    if (
+      this.state.game.Properties.DisableConferenceChat ||
+      this.state.game.Properties.DisableGroupChat ||
+      this.state.game.Properties.DisablePrivateChat
+    ) {
+      icons.push(
+        <MaterialUI.Tooltip
+          key={itemKey++}
+          disableFocusListener
+          title="Chat disabled"
+        >
+          <MaterialUI.SvgIcon className={sixteenBySixteenClass}>
+            <g
+              id="Artboard"
+              stroke="none"
+              strokeWidth="1"
+              fill="none"
+              fillRule="evenodd"
+            >
+              <g id="message-24px">
+                <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                <path
+                  d="M2.4,2.614 L20.5847763,20.7989899 L20.598,20.784 L20.7989899,20.9842712 L19.3847763,22.3984848 L14.986,18 L6,18 L2,22 L2.008,5.022 L1,4.0137085 L2.4,2.614 Z M20,2 C21.05,2 21.9177686,2.82004132 21.9944872,3.85130541 L22,4 L22,16 C22,16.9134058 21.3794387,17.6889091 20.539101,17.925725 L16.614,14 L18,14 L18,12 L14.614,12 L13.614,11 L18,11 L18,9 L11.614,9 L10.614,8 L18,8 L18,6 L8.614,6 L4.614,2 L20,2 Z M8.987,12 L6,12 L6,14 L10.986,14 L8.987,12 Z M6,9.013 L6,11 L7.987,11 L6,9.013 Z"
+                  id="Combined-Shape"
+                  fill="#000000"
+                  fillRule="nonzero"
+                ></path>
+              </g>
+            </g>
+          </MaterialUI.SvgIcon>
+        </MaterialUI.Tooltip>
+      );
+    }
+    if (this.state.game.Properties.Private) {
+      this.addIcon(icons, "\ue897", "black");
+    }
+    if (this.state.game.Properties.NationAllocation == 1) {
+      this.addIcon(icons, "\ue065", "black");
+    }
+    return <MaterialUI.Box display="inline">{icons}</MaterialUI.Box>;
+  }
 
-				<MaterialUI.Typography>
-					Nation selection:{" "}
-					{this.state.game.Properties.NationAllocation == 1
-						? "Preferences"
-						: "Random"}{" "}
-				</MaterialUI.Typography>
-			</div>
-		);
+  render() {
+    let expandedGameCells = [];
+    expandedGameCells.push(
+      <div style={{ width: "100%", display: "flex", alignItems: "center" }}>
+        <MaterialUI.Icon style={{ marginRight: "8px" }}>
+          {helpers.createIcon("\ue55b")}
+        </MaterialUI.Icon>
+        <MaterialUI.Typography>
+          Game variant: {this.state.game.Properties.Variant}
+        </MaterialUI.Typography>
+      </div>
+    );
+    expandedGameCells.push(
+      <div style={{ width: "100%", display: "flex", alignItems: "center" }}>
+        <MaterialUI.Icon style={{ marginRight: "8px" }}>
+          {helpers.createIcon("\ue01b")}
+        </MaterialUI.Icon>
+        <MaterialUI.Typography>
+          Phase deadline{" "}
+          {helpers.minutesToDuration(
+            this.state.game.Properties.PhaseLengthMinutes
+          )}
+        </MaterialUI.Typography>
+      </div>
+    );
+    if (this.state.game.Properties.NonMovementPhaseLengthMinutes) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue01b")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Non movement phase deadline{" "}
+            {helpers.minutesToDuration(
+              this.state.game.Properties.NonMovementPhaseLengthMinutes
+            )}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.LastYear) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue88b")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Ends after year: {this.state.game.Properties.LastYear}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    expandedGameCells.push(
+      <div style={{ width: "100%", display: "flex", alignItems: "center" }}>
+        <MaterialUI.Icon style={{ marginRight: "8px" }}>
+          <MaterialUI.SvgIcon>
+            <g
+              id="Artboard"
+              stroke="none"
+              strokeWidth="1"
+              fill="none"
+              fillRule="evenodd"
+            >
+              <g id="timelapse-24px">
+                <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                <path
+                  d="M12,6 C12.5719312,6 13.1251722,6.08002251 13.6491373,6.22948186 L12,12 Z M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M12,20 C7.58,20 4,16.42 4,12 C4,7.58 7.58,4 12,4 C16.42,4 20,7.58 20,12 C20,16.42 16.42,20 12,20 Z"
+                  id="Shape"
+                  fill="#000000"
+                  fillRule="nonzero"
+                ></path>
+              </g>
+            </g>
+          </MaterialUI.SvgIcon>
+        </MaterialUI.Icon>
+        <MaterialUI.Typography>
+          Created: {helpers.timeStrToDate(this.state.game.Properties.CreatedAt)}{" "}
+        </MaterialUI.Typography>
+      </div>
+    );
+    if (this.state.game.Properties.Started) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue422")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Started:{" "}
+            {helpers.timeStrToDate(this.state.game.Properties.StartedAt)}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.Finished) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            <MaterialUI.SvgIcon>
+              <g
+                id="Artboard"
+                stroke="none"
+                strokeWidth="1"
+                fill="none"
+                fillRule="evenodd"
+              >
+                <g id="timelapse-24px">
+                  <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                  <path
+                    d="M12,6 C15.3137085,6 18,8.6862915 18,12 C18,15.3137085 15.3137085,18 12,18 C8.6862915,18 6,15.3137085 6,12 C6,9.25822274 7.83903025,6.94597402 10.3508627,6.22948186 L12,12 Z M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M12,20 C7.58,20 4,16.42 4,12 C4,7.58 7.58,4 12,4 C16.42,4 20,7.58 20,12 C20,16.42 16.42,20 12,20 Z"
+                    id="Shape"
+                    fill="#000000"
+                    fillRule="nonzero"
+                  ></path>
+                </g>
+              </g>
+            </MaterialUI.SvgIcon>
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Finished:{" "}
+            {helpers.timeStrToDate(this.state.game.Properties.FinishedAt)}{" "}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    expandedGameCells.push(
+      <div style={{ width: "100%", display: "flex", alignItems: "center" }}>
+        {this.state.game.Properties.NationAllocation == 1 ? (
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue065")}
+          </MaterialUI.Icon>
+        ) : (
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            <MaterialUI.SvgIcon>
+              <g
+                id="Artboard"
+                stroke="none"
+                strokeWidth="1"
+                fill="none"
+                fillRule="evenodd"
+              >
+                <g id="playlist_add_check-24px-(1)">
+                  <rect
+                    id="Rectangle"
+                    x="0"
+                    y="0"
+                    width="24"
+                    height="24"
+                  ></rect>
+                  <path
+                    d="M14,10 L2,10 L2,12 L14,12 L14,10 Z M14,6 L2,6 L2,8 L14,8 L14,6 Z M18.51,16.25 L21,18.75 L18.51,21.25 L18.51,19.5 L13,19.5 L13,18 L18.51,18 L18.51,16.25 Z M15.49,12 L15.49,13.75 L21,13.75 L21,15.25 L15.49,15.25 L15.49,17 L13,14.5 L15.49,12 Z M10,14 L10,16 L2,16 L2,14 L10,14 Z"
+                    id="Shape"
+                    fill="#000000"
+                    fillRule="nonzero"
+                  ></path>
+                </g>
+                <g id="loop-24px">
+                  <polygon id="Path" points="13 12 26 12 26 25 13 25"></polygon>
+                  <g id="transfer_within_a_station-24px">
+                    <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                  </g>
+                </g>
+              </g>
+            </MaterialUI.SvgIcon>
+          </MaterialUI.Icon>
+        )}
 
-		if (this.state.game.Properties.MinRating) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue83a")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Minimum rating: {this.state.game.Properties.MinRating}{" "}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.MaxRating) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue83a")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Maximum rating: {this.state.game.Properties.MaxRating}{" "}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.MinReliability) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue425")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Minimum reliability:{" "}
-						{this.state.game.Properties.MinReliability}{" "}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.MinQuickness) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						{helpers.createIcon("\ue425")}
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Minimum quickness:{" "}
-						{this.state.game.Properties.MinQuickness}{" "}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.MaxHated) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						<MaterialUI.SvgIcon>
-							<g
-								id="Artboard"
-								stroke="none"
-								strokeWidth="1"
-								fill="none"
-								fillRule="evenodd"
-							>
-								<g
-									id="emoticon-angry-outline"
-									transform="translate(1.000000, 1.000000)"
-									fill="#000000"
-									fillRule="nonzero"
-								>
-									<path
-										d="M1.05,0.08 L13.4993434,12.5296465 L13.509,12.519 L13.9296465,12.939697 L12.939697,13.9296465 L11.4291042,12.4206404 C10.184652,13.4375261 8.62132228,14 7,14 C5.14348457,14 3.36300718,13.2625021 2.05025253,11.9497475 C0.737497883,10.6369928 0,8.85651543 0,7 C0,5.31921341 0.592383418,3.77678538 1.57975754,2.57010863 L0.0703535444,1.06030304 L1.05,0.08 Z M2.5761358,3.566003 C1.83897141,4.51428911 1.4,5.70588092 1.4,7 C1.4,10.0927946 3.9072054,12.6 7,12.6 C8.29411908,12.6 9.48571089,12.1610286 10.433997,11.4238642 L9.305,10.295 L8.939,10.661 C8.624,10.15 7.875,9.8 7,9.8 C6.125,9.8 5.376,10.15 5.061,10.661 L4.067,9.667 C4.697,8.904 5.775,8.4 7,8.4 C7.14658996,8.4 7.29107491,8.40721717 7.43293907,8.42123168 L5.12607623,6.1169691 C4.95837689,6.23170489 4.75906667,6.3 4.55,6.3 C3.99,6.3 3.5,5.81 3.5,5.25 L3.5,4.49 L2.5761358,3.566003 Z M7,0 C8.85651543,0 10.6369928,0.737497883 11.9497475,2.05025253 C13.2625021,3.36300718 14,5.14348457 14,7 C14,8.14229525 13.7207968,9.25580388 13.2001824,10.2492879 L12.1507771,9.20127306 C12.4399256,8.52556954 12.6,7.78147846 12.6,7 C12.6,5.51478766 12.0100017,4.09040574 10.959798,3.04020203 C9.90959426,1.98999831 8.48521234,1.4 7,1.4 C6.21813639,1.4 5.47369701,1.56023219 4.79772792,1.84965051 L3.74828763,0.799495095 C4.71989309,0.288908589 5.82620744,0 7,0 Z M10.5,4.2 L10.5,5.25 C10.5,5.81 10.01,6.3 9.45,6.3 C8.89,6.3 8.4,5.81 8.4,5.25 L10.5,4.2 Z"
-										id="Combined-Shape"
-									></path>
-								</g>
-							</g>
-						</MaterialUI.SvgIcon>
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Maximum hated:
-						{this.state.game.Properties.MaxHated}{" "}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (this.state.game.Properties.MaxHater) {
-			expandedGameCells.push(
-				<div
-					style={{
-						width: "100%",
-						display: "flex",
-						alignItems: "center"
-					}}
-				>
-					<MaterialUI.Icon style={{ marginRight: "8px" }}>
-						<MaterialUI.SvgIcon>
-							<g
-								id="Artboard"
-								stroke="none"
-								strokeWidth="1"
-								fill="none"
-								fillRule="evenodd"
-							>
-								<g
-									id="emoticon-angry-outline"
-									transform="translate(1.000000, 1.000000)"
-									fill="#000000"
-									fillRule="nonzero"
-								>
-									<path
-										d="M1.05,0.08 L13.4993434,12.5296465 L13.509,12.519 L13.9296465,12.939697 L12.939697,13.9296465 L11.4291042,12.4206404 C10.184652,13.4375261 8.62132228,14 7,14 C5.14348457,14 3.36300718,13.2625021 2.05025253,11.9497475 C0.737497883,10.6369928 0,8.85651543 0,7 C0,5.31921341 0.592383418,3.77678538 1.57975754,2.57010863 L0.0703535444,1.06030304 L1.05,0.08 Z M2.5761358,3.566003 C1.83897141,4.51428911 1.4,5.70588092 1.4,7 C1.4,10.0927946 3.9072054,12.6 7,12.6 C8.29411908,12.6 9.48571089,12.1610286 10.433997,11.4238642 L9.305,10.295 L8.939,10.661 C8.624,10.15 7.875,9.8 7,9.8 C6.125,9.8 5.376,10.15 5.061,10.661 L4.067,9.667 C4.697,8.904 5.775,8.4 7,8.4 C7.14658996,8.4 7.29107491,8.40721717 7.43293907,8.42123168 L5.12607623,6.1169691 C4.95837689,6.23170489 4.75906667,6.3 4.55,6.3 C3.99,6.3 3.5,5.81 3.5,5.25 L3.5,4.49 L2.5761358,3.566003 Z M7,0 C8.85651543,0 10.6369928,0.737497883 11.9497475,2.05025253 C13.2625021,3.36300718 14,5.14348457 14,7 C14,8.14229525 13.7207968,9.25580388 13.2001824,10.2492879 L12.1507771,9.20127306 C12.4399256,8.52556954 12.6,7.78147846 12.6,7 C12.6,5.51478766 12.0100017,4.09040574 10.959798,3.04020203 C9.90959426,1.98999831 8.48521234,1.4 7,1.4 C6.21813639,1.4 5.47369701,1.56023219 4.79772792,1.84965051 L3.74828763,0.799495095 C4.71989309,0.288908589 5.82620744,0 7,0 Z M10.5,4.2 L10.5,5.25 C10.5,5.81 10.01,6.3 9.45,6.3 C8.89,6.3 8.4,5.81 8.4,5.25 L10.5,4.2 Z"
-										id="Combined-Shape"
-									></path>
-								</g>
-							</g>
-						</MaterialUI.SvgIcon>
-					</MaterialUI.Icon>
-					<MaterialUI.Typography>
-						Maximum hater: {this.state.game.Properties.MaxHater}
-					</MaterialUI.Typography>
-				</div>
-			);
-		}
-		if (
-			this.state.game.Properties.DisableConferenceChat ||
-			this.state.game.Properties.DisableGroupChat ||
-			this.state.game.Properties.DisablePrivateChat
-		) {
-			if (
-				this.state.game.Properties.DisableConferenceChat &&
-				this.state.game.Properties.DisableGroupChat &&
-				this.state.game.Properties.DisablePrivateChat
-			) {
-				// Add two columns because this is required for formatting nicely.
-				expandedGameCells.push(
-					<div
-						style={{
-							width: "100%",
-							display: "flex",
-							alignItems: "center"
-						}}
-					>
-						<MaterialUI.Icon style={{ marginRight: "8px" }}>
-							<MaterialUI.SvgIcon>
-								<g
-									id="Artboard"
-									stroke="none"
-									strokeWidth="1"
-									fill="none"
-									fillRule="evenodd"
-								>
-									<g id="message-24px">
-										<polygon
-											id="Path"
-											points="0 0 24 0 24 24 0 24"
-										></polygon>
-										<path
-											d="M2.4,2.614 L20.5847763,20.7989899 L20.598,20.784 L20.7989899,20.9842712 L19.3847763,22.3984848 L14.986,18 L6,18 L2,22 L2.008,5.022 L1,4.0137085 L2.4,2.614 Z M20,2 C21.05,2 21.9177686,2.82004132 21.9944872,3.85130541 L22,4 L22,16 C22,16.9134058 21.3794387,17.6889091 20.539101,17.925725 L16.614,14 L18,14 L18,12 L14.614,12 L13.614,11 L18,11 L18,9 L11.614,9 L10.614,8 L18,8 L18,6 L8.614,6 L4.614,2 L20,2 Z M8.987,12 L6,12 L6,14 L10.986,14 L8.987,12 Z M6,9.013 L6,11 L7.987,11 L6,9.013 Z"
-											id="Combined-Shape"
-											fill="#000000"
-											fillRule="nonzero"
-										></path>
-									</g>
-								</g>
-							</MaterialUI.SvgIcon>
-						</MaterialUI.Icon>
-						<MaterialUI.Typography>
-							No chat (Gunboat)
-						</MaterialUI.Typography>
-					</div>
-				);
-			} else {
-				// Sort channel types by whether they're enabled or disabled.
-				let allChannels = { false: [], true: [] };
-				allChannels[
-					this.state.game.Properties.DisableConferenceChat
-				].push("Conference");
-				allChannels[this.state.game.Properties.DisableGroupChat].push(
-					"Group"
-				);
-				allChannels[this.state.game.Properties.DisablePrivateChat].push(
-					"Private"
-				);
-				expandedGameCells.push(
-					<div
-						style={{
-							width: "100%",
-							display: "flex",
-							alignItems: "center"
-						}}
-					>
-						<MaterialUI.Icon style={{ marginRight: "8px" }}>
-							<MaterialUI.SvgIcon>
-								<g
-									id="Artboard"
-									stroke="none"
-									strokeWidth="1"
-									fill="none"
-									fillRule="evenodd"
-								>
-									<g id="message-24px">
-										<polygon
-											id="Path"
-											points="0 0 24 0 24 24 0 24"
-										></polygon>
-										<path
-											d="M2.4,2.614 L20.5847763,20.7989899 L20.598,20.784 L20.7989899,20.9842712 L19.3847763,22.3984848 L14.986,18 L6,18 L2,22 L2.008,5.022 L1,4.0137085 L2.4,2.614 Z M20,2 C21.05,2 21.9177686,2.82004132 21.9944872,3.85130541 L22,4 L22,16 C22,16.9134058 21.3794387,17.6889091 20.539101,17.925725 L16.614,14 L18,14 L18,12 L14.614,12 L13.614,11 L18,11 L18,9 L11.614,9 L10.614,8 L18,8 L18,6 L8.614,6 L4.614,2 L20,2 Z M8.987,12 L6,12 L6,14 L10.986,14 L8.987,12 Z M6,9.013 L6,11 L7.987,11 L6,9.013 Z"
-											id="Combined-Shape"
-											fill="#000000"
-											fillRule="nonzero"
-										></path>
-									</g>
-								</g>
-							</MaterialUI.SvgIcon>
-						</MaterialUI.Icon>
-						<MaterialUI.Typography>
-							{" "}
-							{allChannels[false].join(" & ")} chat off
-						</MaterialUI.Typography>
-					</div>
-				);
-				expandedGameCells.push(
-					<div
-						style={{
-							width: "100%",
-							display: "flex",
-							alignItems: "center"
-						}}
-					>
-						<MaterialUI.Icon style={{ marginRight: "8px" }}>
-							{helpers.createIcon("\ue0c9")}
-						</MaterialUI.Icon>
-						<MaterialUI.Typography>
-							{" "}
-							{allChannels[true].join(" & ")} chat on{" "}
-						</MaterialUI.Typography>
-					</div>
-				);
-			}
-		}
-		let expandedGameItems = [];
-		let itemKey = 0;
+        <MaterialUI.Typography>
+          Nation selection:{" "}
+          {this.state.game.Properties.NationAllocation == 1
+            ? "Preferences"
+            : "Random"}{" "}
+        </MaterialUI.Typography>
+      </div>
+    );
 
-		let buttons = [];
+    if (this.state.game.Properties.MinRating) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue83a")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Minimum rating: {this.state.game.Properties.MinRating}{" "}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.MaxRating) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue83a")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Maximum rating: {this.state.game.Properties.MaxRating}{" "}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.MinReliability) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue425")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Minimum reliability: {this.state.game.Properties.MinReliability}{" "}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.MinQuickness) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            {helpers.createIcon("\ue425")}
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Minimum quickness: {this.state.game.Properties.MinQuickness}{" "}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.MaxHated) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            <MaterialUI.SvgIcon>
+              <g
+                id="Artboard"
+                stroke="none"
+                strokeWidth="1"
+                fill="none"
+                fillRule="evenodd"
+              >
+                <g
+                  id="emoticon-angry-outline"
+                  transform="translate(1.000000, 1.000000)"
+                  fill="#000000"
+                  fillRule="nonzero"
+                >
+                  <path
+                    d="M1.05,0.08 L13.4993434,12.5296465 L13.509,12.519 L13.9296465,12.939697 L12.939697,13.9296465 L11.4291042,12.4206404 C10.184652,13.4375261 8.62132228,14 7,14 C5.14348457,14 3.36300718,13.2625021 2.05025253,11.9497475 C0.737497883,10.6369928 0,8.85651543 0,7 C0,5.31921341 0.592383418,3.77678538 1.57975754,2.57010863 L0.0703535444,1.06030304 L1.05,0.08 Z M2.5761358,3.566003 C1.83897141,4.51428911 1.4,5.70588092 1.4,7 C1.4,10.0927946 3.9072054,12.6 7,12.6 C8.29411908,12.6 9.48571089,12.1610286 10.433997,11.4238642 L9.305,10.295 L8.939,10.661 C8.624,10.15 7.875,9.8 7,9.8 C6.125,9.8 5.376,10.15 5.061,10.661 L4.067,9.667 C4.697,8.904 5.775,8.4 7,8.4 C7.14658996,8.4 7.29107491,8.40721717 7.43293907,8.42123168 L5.12607623,6.1169691 C4.95837689,6.23170489 4.75906667,6.3 4.55,6.3 C3.99,6.3 3.5,5.81 3.5,5.25 L3.5,4.49 L2.5761358,3.566003 Z M7,0 C8.85651543,0 10.6369928,0.737497883 11.9497475,2.05025253 C13.2625021,3.36300718 14,5.14348457 14,7 C14,8.14229525 13.7207968,9.25580388 13.2001824,10.2492879 L12.1507771,9.20127306 C12.4399256,8.52556954 12.6,7.78147846 12.6,7 C12.6,5.51478766 12.0100017,4.09040574 10.959798,3.04020203 C9.90959426,1.98999831 8.48521234,1.4 7,1.4 C6.21813639,1.4 5.47369701,1.56023219 4.79772792,1.84965051 L3.74828763,0.799495095 C4.71989309,0.288908589 5.82620744,0 7,0 Z M10.5,4.2 L10.5,5.25 C10.5,5.81 10.01,6.3 9.45,6.3 C8.89,6.3 8.4,5.81 8.4,5.25 L10.5,4.2 Z"
+                    id="Combined-Shape"
+                  ></path>
+                </g>
+              </g>
+            </MaterialUI.SvgIcon>
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Maximum hated:
+            {this.state.game.Properties.MaxHated}{" "}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (this.state.game.Properties.MaxHater) {
+      expandedGameCells.push(
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <MaterialUI.Icon style={{ marginRight: "8px" }}>
+            <MaterialUI.SvgIcon>
+              <g
+                id="Artboard"
+                stroke="none"
+                strokeWidth="1"
+                fill="none"
+                fillRule="evenodd"
+              >
+                <g
+                  id="emoticon-angry-outline"
+                  transform="translate(1.000000, 1.000000)"
+                  fill="#000000"
+                  fillRule="nonzero"
+                >
+                  <path
+                    d="M1.05,0.08 L13.4993434,12.5296465 L13.509,12.519 L13.9296465,12.939697 L12.939697,13.9296465 L11.4291042,12.4206404 C10.184652,13.4375261 8.62132228,14 7,14 C5.14348457,14 3.36300718,13.2625021 2.05025253,11.9497475 C0.737497883,10.6369928 0,8.85651543 0,7 C0,5.31921341 0.592383418,3.77678538 1.57975754,2.57010863 L0.0703535444,1.06030304 L1.05,0.08 Z M2.5761358,3.566003 C1.83897141,4.51428911 1.4,5.70588092 1.4,7 C1.4,10.0927946 3.9072054,12.6 7,12.6 C8.29411908,12.6 9.48571089,12.1610286 10.433997,11.4238642 L9.305,10.295 L8.939,10.661 C8.624,10.15 7.875,9.8 7,9.8 C6.125,9.8 5.376,10.15 5.061,10.661 L4.067,9.667 C4.697,8.904 5.775,8.4 7,8.4 C7.14658996,8.4 7.29107491,8.40721717 7.43293907,8.42123168 L5.12607623,6.1169691 C4.95837689,6.23170489 4.75906667,6.3 4.55,6.3 C3.99,6.3 3.5,5.81 3.5,5.25 L3.5,4.49 L2.5761358,3.566003 Z M7,0 C8.85651543,0 10.6369928,0.737497883 11.9497475,2.05025253 C13.2625021,3.36300718 14,5.14348457 14,7 C14,8.14229525 13.7207968,9.25580388 13.2001824,10.2492879 L12.1507771,9.20127306 C12.4399256,8.52556954 12.6,7.78147846 12.6,7 C12.6,5.51478766 12.0100017,4.09040574 10.959798,3.04020203 C9.90959426,1.98999831 8.48521234,1.4 7,1.4 C6.21813639,1.4 5.47369701,1.56023219 4.79772792,1.84965051 L3.74828763,0.799495095 C4.71989309,0.288908589 5.82620744,0 7,0 Z M10.5,4.2 L10.5,5.25 C10.5,5.81 10.01,6.3 9.45,6.3 C8.89,6.3 8.4,5.81 8.4,5.25 L10.5,4.2 Z"
+                    id="Combined-Shape"
+                  ></path>
+                </g>
+              </g>
+            </MaterialUI.SvgIcon>
+          </MaterialUI.Icon>
+          <MaterialUI.Typography>
+            Maximum hater: {this.state.game.Properties.MaxHater}
+          </MaterialUI.Typography>
+        </div>
+      );
+    }
+    if (
+      this.state.game.Properties.DisableConferenceChat ||
+      this.state.game.Properties.DisableGroupChat ||
+      this.state.game.Properties.DisablePrivateChat
+    ) {
+      if (
+        this.state.game.Properties.DisableConferenceChat &&
+        this.state.game.Properties.DisableGroupChat &&
+        this.state.game.Properties.DisablePrivateChat
+      ) {
+        // Add two columns because this is required for formatting nicely.
+        expandedGameCells.push(
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <MaterialUI.Icon style={{ marginRight: "8px" }}>
+              <MaterialUI.SvgIcon>
+                <g
+                  id="Artboard"
+                  stroke="none"
+                  strokeWidth="1"
+                  fill="none"
+                  fillRule="evenodd"
+                >
+                  <g id="message-24px">
+                    <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                    <path
+                      d="M2.4,2.614 L20.5847763,20.7989899 L20.598,20.784 L20.7989899,20.9842712 L19.3847763,22.3984848 L14.986,18 L6,18 L2,22 L2.008,5.022 L1,4.0137085 L2.4,2.614 Z M20,2 C21.05,2 21.9177686,2.82004132 21.9944872,3.85130541 L22,4 L22,16 C22,16.9134058 21.3794387,17.6889091 20.539101,17.925725 L16.614,14 L18,14 L18,12 L14.614,12 L13.614,11 L18,11 L18,9 L11.614,9 L10.614,8 L18,8 L18,6 L8.614,6 L4.614,2 L20,2 Z M8.987,12 L6,12 L6,14 L10.986,14 L8.987,12 Z M6,9.013 L6,11 L7.987,11 L6,9.013 Z"
+                      id="Combined-Shape"
+                      fill="#000000"
+                      fillRule="nonzero"
+                    ></path>
+                  </g>
+                </g>
+              </MaterialUI.SvgIcon>
+            </MaterialUI.Icon>
+            <MaterialUI.Typography>No chat (Gunboat)</MaterialUI.Typography>
+          </div>
+        );
+      } else {
+        // Sort channel types by whether they're enabled or disabled.
+        let allChannels = { false: [], true: [] };
+        allChannels[this.state.game.Properties.DisableConferenceChat].push(
+          "Conference"
+        );
+        allChannels[this.state.game.Properties.DisableGroupChat].push("Group");
+        allChannels[this.state.game.Properties.DisablePrivateChat].push(
+          "Private"
+        );
+        expandedGameCells.push(
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <MaterialUI.Icon style={{ marginRight: "8px" }}>
+              <MaterialUI.SvgIcon>
+                <g
+                  id="Artboard"
+                  stroke="none"
+                  strokeWidth="1"
+                  fill="none"
+                  fillRule="evenodd"
+                >
+                  <g id="message-24px">
+                    <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                    <path
+                      d="M2.4,2.614 L20.5847763,20.7989899 L20.598,20.784 L20.7989899,20.9842712 L19.3847763,22.3984848 L14.986,18 L6,18 L2,22 L2.008,5.022 L1,4.0137085 L2.4,2.614 Z M20,2 C21.05,2 21.9177686,2.82004132 21.9944872,3.85130541 L22,4 L22,16 C22,16.9134058 21.3794387,17.6889091 20.539101,17.925725 L16.614,14 L18,14 L18,12 L14.614,12 L13.614,11 L18,11 L18,9 L11.614,9 L10.614,8 L18,8 L18,6 L8.614,6 L4.614,2 L20,2 Z M8.987,12 L6,12 L6,14 L10.986,14 L8.987,12 Z M6,9.013 L6,11 L7.987,11 L6,9.013 Z"
+                      id="Combined-Shape"
+                      fill="#000000"
+                      fillRule="nonzero"
+                    ></path>
+                  </g>
+                </g>
+              </MaterialUI.SvgIcon>
+            </MaterialUI.Icon>
+            <MaterialUI.Typography>
+              {" "}
+              {allChannels[false].join(" & ")} chat off
+            </MaterialUI.Typography>
+          </div>
+        );
+        expandedGameCells.push(
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <MaterialUI.Icon style={{ marginRight: "8px" }}>
+              {helpers.createIcon("\ue0c9")}
+            </MaterialUI.Icon>
+            <MaterialUI.Typography>
+              {" "}
+              {allChannels[true].join(" & ")} chat on{" "}
+            </MaterialUI.Typography>
+          </div>
+        );
+      }
+    }
+    let expandedGameItems = [];
+    let itemKey = 0;
 
-		if (this.state.game.Properties.ActiveBans) {
-			buttons.push(
-				<MaterialUI.Typography
-					key="banned-notice"
-					className={noticeClass}
-				>
-					You can't join becaues you banned or are banned by a player.
-				</MaterialUI.Typography>
-			);
-		}
-		if (this.state.game.Properties.FailedRequirements) {
-			buttons.push(
-				<MaterialUI.Typography
-					key="requirement-notice"
-					className={noticeClass}
-				>
-					You can't join this game because:{" "}
-					{this.state.game.Properties.FailedRequirements.join(", ")}.
-				</MaterialUI.Typography>
-			);
-		}
+    let buttons = [];
 
-		if (!this.dead) {
-			buttons.push(
-				<MaterialUI.Button
-					variant="outlined"
-					style={{ marginRight: "16px", minWidth: "100px" }}
-					color="primary"
-					onClick={this.viewGame}
-					key={itemKey++}
-				>
-					View
-				</MaterialUI.Button>
-			);
-			if (this.state.member) {
-				buttons.push(
-					<MaterialUI.Button
-						variant="outlined"
-						style={{ marginRight: "16px", minWidth: "100px" }}
-						color="primary"
-						onClick={this.renameGame}
-						key={itemKey++}
-					>
-						Rename
-					</MaterialUI.Button>
-				);
-			}
-		}
-		this.state.game.Links.forEach(link => {
-			if (link.Rel == "join") {
-				if (this.state.game.Properties.PhaseLengthMinutes < 60 * 12) {
-					buttons.unshift(
-						<MaterialUI.Typography
-							key="deadline-warning"
-							className={warningClass}
-						>
-							WARNING: This game has short deadlines (less than 12
-							hours). If it starts while you're unavailable, you
-							might miss parts of the game greatly impacting your
-							reliability score.
-						</MaterialUI.Typography>
-					);
-				}
-				if (
-					this.state.game.Properties.MinReliability == 0 &&
-					Globals.userStats.Properties.Reliability >= 10
-				) {
-					buttons.unshift(
-						<MaterialUI.Typography
-							key="reliability-warning"
-							className={warningClass}
-						>
-							WARNING: We advise you to join a different game,
-							because you have high reliability. Since this game
-							has no reliability requirements, it might have
-							(some) absent players.
-						</MaterialUI.Typography>
-					);
-				}
-				buttons.push(
-					<MaterialUI.Button
-						key={itemKey++}
-						variant="outlined"
-						color="primary"
-						style={{ marginRight: "16px", minWidth: "100px" }}
-						onClick={_ => {
-							this.joinGame(link);
-						}}
-					>
-						Join
-					</MaterialUI.Button>
-				);
-			} else if (link.Rel == "leave") {
-				buttons.push(
-					<MaterialUI.Button
-						key={itemKey++}
-						variant="outlined"
-						color="primary"
-						style={{ marginRight: "16px", minWidth: "100px" }}
-						onClick={_ => {
-							this.leaveGame(link);
-						}}
-					>
-						Leave
-					</MaterialUI.Button>
-				);
-			}
-		});
-		expandedGameItems.push(
-			<div
-				key={itemKey++}
-				style={{
-					dispay: "flex",
-					justifyContent: "space-evenly",
-					marginBottom: "8px"
-				}}
-			>
-				{buttons}
-			</div>
-		);
-		expandedGameCells.forEach(cell =>
-			expandedGameItems.push(<div key={itemKey++}>{cell}</div>)
-		);
+    if (this.state.game.Properties.ActiveBans) {
+      buttons.push(
+        <MaterialUI.Typography key="banned-notice" className={noticeClass}>
+          You can't join becaues you banned or are banned by a player.
+        </MaterialUI.Typography>
+      );
+    }
+    if (this.state.game.Properties.FailedRequirements) {
+      buttons.push(
+        <MaterialUI.Typography key="requirement-notice" className={noticeClass}>
+          You can't join this game because:{" "}
+          {this.state.game.Properties.FailedRequirements.join(", ")}.
+        </MaterialUI.Typography>
+      );
+    }
 
-		let playerList = [];
-		playerList.push(
-			<MaterialUI.Typography
-				key={itemKey++}
-				variant="subtitle2"
-				style={{ color: "rgba(40, 26, 26, 0.7)", marginTop: "4px" }}
-			>
-				Players:
-			</MaterialUI.Typography>
-		);
+    if (!this.dead) {
+      buttons.push(
+        <MaterialUI.Button
+          variant="outlined"
+          style={{ marginRight: "16px", minWidth: "100px", marginBottom: "4px"}}
+          color="primary"
+          onClick={this.viewGame}
+          key={itemKey++}
+        >
+          View
+        </MaterialUI.Button>
+      );
+      if (this.state.member) {
+        buttons.push(
+          <MaterialUI.Button
+            variant="outlined"
+            style={{ marginRight: "16px", minWidth: "100px", marginBottom: "4px"}}
+            color="primary"
+            onClick={this.renameGame}
+            key={itemKey++}
+          >
+            Rename
+          </MaterialUI.Button>
+        );
+      }
+    }
+    this.state.game.Links.forEach((link) => {
+      if (link.Rel == "join") {
+        if (this.state.game.Properties.PhaseLengthMinutes < 60 * 12) {
+          buttons.unshift(
+            <MaterialUI.Typography
+              key="deadline-warning"
+              className={warningClass}
+            >
+              WARNING: This game has short deadlines (less than 12 hours). If it
+              starts while you're unavailable, you might miss parts of the game
+              greatly impacting your reliability score.
+            </MaterialUI.Typography>
+          );
+        }
+        if (
+          this.state.game.Properties.MinReliability == 0 &&
+          Globals.userStats.Properties.Reliability >= 10
+        ) {
+          buttons.unshift(
+            <MaterialUI.Typography
+              key="reliability-warning"
+              className={warningClass}
+            >
+              WARNING: We advise you to join a different game, because you have
+              high reliability. Since this game has no reliability requirements,
+              it might have (some) absent players.
+            </MaterialUI.Typography>
+          );
+        }
+        buttons.push(
+          <MaterialUI.Button
+            key={itemKey++}
+            variant="outlined"
+            color="primary"
+            style={{ marginRight: "16px", minWidth: "100px" }}
+            onClick={(_) => {
+              this.joinGame(link);
+            }}
+          >
+            Join
+          </MaterialUI.Button>
+        );
+      } else if (link.Rel == "leave") {
+        buttons.push(
+          <MaterialUI.Button
+            key={itemKey++}
+            variant="outlined"
+            color="primary"
+            style={{ marginRight: "16px", minWidth: "100px", marginBottom: "4px"}}
+            onClick={(_) => {
+              this.leaveGame(link);
+            }}
+          >
+            Leave
+          </MaterialUI.Button>
+        );
+      }
+    });
+    expandedGameItems.push(
+      <div
+        key={itemKey++}
+        style={{
+          dispay: "flex",
+          justifyContent: "space-evenly",
+          marginBottom: "8px",
+        }}
+      >
+        {buttons}
+      </div>
+    );
+    expandedGameCells.forEach((cell) =>
+      expandedGameItems.push(<div key={itemKey++}>{cell}</div>)
+    );
 
-		this.state.game.Properties.Members.forEach(member => {
-			playerList.push(
-				<div
-					key={itemKey++}
-					style={{ display: "flex", alignItems: "center" }}
-				>
-					<UserAvatar user={member.User} />
-					<MaterialUI.Typography>
-						{member.User.GivenName} {member.User.FamilyName}
-					</MaterialUI.Typography>
-				</div>
-			);
-		});
+    let playerList = [];
+    playerList.push(
+      <MaterialUI.Typography
+        key={itemKey++}
+        variant="subtitle2"
+        style={{ color: "rgba(40, 26, 26, 0.7)", marginTop: "4px" }}
+      >
+        Players:
+      </MaterialUI.Typography>
+    );
 
-		let summary = (
-			<div
-				style={{
-					display: "flex",
-					flexDirection: "column",
-					width: "100%",
+    this.state.game.Properties.Members.forEach((member) => {
+      playerList.push(
+        <div key={itemKey++} style={{ display: "flex", alignItems: "center" }}>
+          <UserAvatar user={member.User} />
+          <MaterialUI.Typography>
+            {member.User.GivenName} {member.User.FamilyName}
+          </MaterialUI.Typography>
+        </div>
+      );
+    });
 
-					marginTop: "8px"
-				}}
-			>
-				{(_ => {
-					if (this.state.game.Properties.Started) {
-						return (
-							<React.Fragment>
-								{/* IF STARTED */}
-								<div
-									style={{
-										display: "flex",
-										flexDirection: "row",
-										justifyContent: "space-between"
-									}}
-								>
-									{this.state.member &&
-									this.state.member.UnreadMessages > 0 ? (
-										<MaterialUI.Badge
-											key={itemKey++}
-											badgeContent={
-												this.state.member.UnreadMessages
-											}
-											color="primary"
-											style={{
-												maxWidth: "calc(100% - 70px)"
-											}}
-										>
-											<MaterialUI.Typography
-												textroverflow="ellipsis"
-												noWrap
-												style={{
-													color: "rgba(40, 26, 26, 1)"
-												}}
-											>
-												{helpers.gameDesc(
-													this.state.game
-												)}
-											</MaterialUI.Typography>
-										</MaterialUI.Badge>
-									) : (
-										<MaterialUI.Typography
-											key={itemKey++}
-											textroverflow="ellipsis"
-											noWrap={true}
-											style={{
-												minWidth: "60px",
-												color: "rgba(40, 26, 26, 1)"
-											}}
-										>
-											{helpers.gameDesc(this.state.game)}
-										</MaterialUI.Typography>
-									)}
+    let summary = (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
 
-									<div
-										id="Timer"
-										key={itemKey++}
-										style={{
-											alignSelf: "center",
-											display: "flex",
-											alignItems: "center",
-											color: "#281A1A"
-										}}
-									>
-										{this.state.member != null &&
-										this.state.game.Properties.Started &&
-										!this.state.game.Properties.Finished ? (
-											this.state.member.NewestPhaseState
-												.OnProbation ? (
-												<MaterialUI.SvgIcon>
-													<path
-														d="M2.98188996,2.24133335 L21.3666663,20.6261097 L20.0261097,21.9666663 L19.0573333,20.998 L19,21 L5,21 C3.95,21 3.0822314,20.1799587 3.00551277,19.1486946 L3,19 L3,5 L3.00233335,4.942 L1.64133335,3.58188996 L2.98188996,2.24133335 Z M12,1 C13.235,1 14.2895,1.7581 14.75196,2.828465 L14.82,3 L19,3 C20.05,3 20.9177686,3.82004132 20.9944872,4.85130541 L21,5 L21,17.963 L16.037,13 L17,13 L17,11 L14.037,11 L12.037,9 L17,9 L17,7 L10.037,7 L6.037,3 L9.18,3 C9.579,1.898 10.5917,1.0848 11.80656,1.006235 L12,1 Z M13.0593333,15 L7,15 L7,17 L15.0593333,17 L13.0593333,15 Z M11.0593333,13 L9.06033335,11 L7,11 L7,13 L11.0593333,13 Z M12,3 C11.45,3 11,3.45 11,4 C11,4.55 11.45,5 12,5 C12.55,5 13,4.55 13,4 C13,3.45 12.55,3 12,3 Z"
-														id="Shape"
-														fill="#b71c1c"
-														fillRule="nonzero"
-													></path>
-												</MaterialUI.SvgIcon>
-											) : this.state.member
-													.NewestPhaseState
-													.ReadyToResolve ? (
-												<MaterialUI.SvgIcon>
-													<path
-														d="M9,0 C10.3,0 11.4,0.84 11.82,2 L11.82,2 L16,2 C17.1045695,2 18,2.8954305 18,4 L18,4 L18,18 C18,19.1045695 17.1045695,20 16,20 L16,20 L2,20 C0.8954305,20 0,19.1045695 0,18 L0,18 L0,4 C0,2.8954305 0.8954305,2 2,2 L2,2 L6.18,2 C6.6,0.84 7.7,0 9,0 Z M13.4347826,7 L7.70608696,12.7391304 L4.56521739,9.60869565 L3,11.173913 L7.70608696,15.8695652 L15,8.56521739 L13.4347826,7 Z M9,2 C8.44771525,2 8,2.44771525 8,3 C8,3.55228475 8.44771525,4 9,4 C9.55228475,4 10,3.55228475 10,3 C10,2.44771525 9.55228475,2 9,2 Z"
-														fill="#281A1A"
-														id="Combined-Shape"
-													></path>
-												</MaterialUI.SvgIcon>
-											) : (
-												helpers.createIcon("\ue422")
-											)
-										) : (
-											""
-										)}
-										<MaterialUI.Typography
-											variant="body2"
-											style={{
-												paddingLeft: "2px",
-												color: "rgba(40, 26, 26, 1)"
-											}}
-										>
-											{this.state.game.Properties.Finished
-												? helpers.minutesToDuration(
-														-this.state.game
-															.Properties
-															.FinishedAgo /
-															1000000000 /
-															60,
-														true
-												  )
-												: helpers.minutesToDuration(
-														this.state.game
-															.Properties
-															.NewestPhaseMeta[0]
-															.NextDeadlineIn /
-															1000000000 /
-															60,
-														true
-												  )}
-										</MaterialUI.Typography>
-									</div>
-								</div>
-								<div
-									key={itemKey++}
-									className={secondRowSummaryClass}
-								>
-									<MaterialUI.Typography
-										textroverflow="ellipsis"
-										noWrap={true}
-										display="inline"
-										variant="caption"
-										id="variant"
-										className={secondRowSummaryColorClass}
-									>
-										{this.state.game.Properties.Variant}{" "}
-										{helpers.phaseLengthDisplay(
-											this.state.game.Properties
-										)}
-									</MaterialUI.Typography>
-									<div className={summaryIconsAndPhaseClass}>
-										<div className={summaryIconsClass}>
-											{this.getIcons()}
-										</div>
-										<MaterialUI.Typography
-											variant="caption"
-											className={
-												secondRowSummaryColorClass
-											}
-										>
-											{
-												this.state.game.Properties
-													.NewestPhaseMeta[0].Season
-											}{" "}
-											{
-												this.state.game.Properties
-													.NewestPhaseMeta[0].Year
-											}
-											,{" "}
-											{
-												this.state.game.Properties
-													.NewestPhaseMeta[0].Type
-											}
-										</MaterialUI.Typography>
-									</div>
-								</div>
-							</React.Fragment>
-						);
-					} else {
-						return (
-							<React.Fragment>
-								{/* IF STARTED */}
-								<div
-									style={{
-										display: "flex",
-										flexDirection: "row",
-										justifyContent: "space-between"
-									}}
-								>
-									<MaterialUI.Typography
-										key={itemKey++}
-										textroverflow="ellipsis"
-										noWrap={true}
-										style={{}}
-									>
-										{helpers.gameDesc(this.state.game)}
-									</MaterialUI.Typography>
+          marginTop: "8px",
+        }}
+      >
+        {((_) => {
+          if (this.state.game.Properties.Started) {
+            return (
+              <React.Fragment>
+                {/* IF STARTED */}
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  {this.state.member && this.state.member.UnreadMessages > 0 ? (
+                    <MaterialUI.Badge
+                      key={itemKey++}
+                      badgeContent={this.state.member.UnreadMessages}
+                      color="primary"
+                      style={{
+                        maxWidth: "calc(100% - 70px)",
+                      }}
+                    >
+                      <MaterialUI.Typography
+                        textroverflow="ellipsis"
+                        noWrap
+                        style={{
+                          color: "rgba(40, 26, 26, 1)",
+                        }}
+                      >
+                        {helpers.gameDesc(this.state.game)}
+                      </MaterialUI.Typography>
+                    </MaterialUI.Badge>
+                  ) : (
+                    <MaterialUI.Typography
+                      key={itemKey++}
+                      textroverflow="ellipsis"
+                      noWrap={true}
+                      style={{
+                        minWidth: "60px",
+                        color: "rgba(40, 26, 26, 1)",
+                      }}
+                    >
+                      {helpers.gameDesc(this.state.game)}
+                    </MaterialUI.Typography>
+                  )}
 
-									<div
-										id="Join"
-										key={itemKey++}
-										style={{
-											alignSelf: "center",
-											display: "flex",
-											alignItems: "center"
-										}}
-									>
-										{helpers.createIcon("\ue7fb")}{" "}
-										<MaterialUI.Typography
-											variant="body2"
-											style={{ paddingLeft: "2px" }}
-										>
-											{
-												this.state.game.Properties
-													.NMembers
-											}
-											/
-											{
-												this.variant.Properties.Nations
-													.length
-											}{" "}
-										</MaterialUI.Typography>
-									</div>
-								</div>
-								<div
-									style={{
-										display: "flex",
-										flexDirection: "row",
-										justifyContent: "space-between"
-									}}
-								>
-									<MaterialUI.Typography
-										textroverflow="ellipsis"
-										noWrap={true}
-										display="inline"
-										variant="caption"
-										style={{
-											color: "rgba(40, 26, 26, 0.7)"
-										}}
-									>
-										{this.state.game.Properties.Variant}{" "}
-										{helpers.phaseLengthDisplay(
-											this.state.game.Properties
-										)}
-									</MaterialUI.Typography>
-									<div> {this.getIcons()}</div>
-								</div>
-							</React.Fragment>
-						);
-					}
-				})()}
+                  <div
+                    id="Timer"
+                    key={itemKey++}
+                    style={{
+                      alignSelf: "center",
+                      display: "flex",
+                      alignItems: "center",
+                      color: "#281A1A",
+                    }}
+                  >
+                    {this.state.member != null &&
+                    this.state.game.Properties.Started &&
+                    !this.state.game.Properties.Finished ? (
+                      this.state.member.NewestPhaseState.OnProbation ? (
+                        <MaterialUI.SvgIcon>
+                          <path
+                            d="M2.98188996,2.24133335 L21.3666663,20.6261097 L20.0261097,21.9666663 L19.0573333,20.998 L19,21 L5,21 C3.95,21 3.0822314,20.1799587 3.00551277,19.1486946 L3,19 L3,5 L3.00233335,4.942 L1.64133335,3.58188996 L2.98188996,2.24133335 Z M12,1 C13.235,1 14.2895,1.7581 14.75196,2.828465 L14.82,3 L19,3 C20.05,3 20.9177686,3.82004132 20.9944872,4.85130541 L21,5 L21,17.963 L16.037,13 L17,13 L17,11 L14.037,11 L12.037,9 L17,9 L17,7 L10.037,7 L6.037,3 L9.18,3 C9.579,1.898 10.5917,1.0848 11.80656,1.006235 L12,1 Z M13.0593333,15 L7,15 L7,17 L15.0593333,17 L13.0593333,15 Z M11.0593333,13 L9.06033335,11 L7,11 L7,13 L11.0593333,13 Z M12,3 C11.45,3 11,3.45 11,4 C11,4.55 11.45,5 12,5 C12.55,5 13,4.55 13,4 C13,3.45 12.55,3 12,3 Z"
+                            id="Shape"
+                            fill="#b71c1c"
+                            fillRule="nonzero"
+                          ></path>
+                        </MaterialUI.SvgIcon>
+                      ) : this.state.member.NewestPhaseState.ReadyToResolve ? (
+                        <MaterialUI.SvgIcon>
+                          <path
+                            d="M9,0 C10.3,0 11.4,0.84 11.82,2 L11.82,2 L16,2 C17.1045695,2 18,2.8954305 18,4 L18,4 L18,18 C18,19.1045695 17.1045695,20 16,20 L16,20 L2,20 C0.8954305,20 0,19.1045695 0,18 L0,18 L0,4 C0,2.8954305 0.8954305,2 2,2 L2,2 L6.18,2 C6.6,0.84 7.7,0 9,0 Z M13.4347826,7 L7.70608696,12.7391304 L4.56521739,9.60869565 L3,11.173913 L7.70608696,15.8695652 L15,8.56521739 L13.4347826,7 Z M9,2 C8.44771525,2 8,2.44771525 8,3 C8,3.55228475 8.44771525,4 9,4 C9.55228475,4 10,3.55228475 10,3 C10,2.44771525 9.55228475,2 9,2 Z"
+                            fill="#281A1A"
+                            id="Combined-Shape"
+                          ></path>
+                        </MaterialUI.SvgIcon>
+                      ) : (
+                        helpers.createIcon("\ue422")
+                      )
+                    ) : (
+                      ""
+                    )}
+                    <MaterialUI.Typography
+                      variant="body2"
+                      style={{
+                        paddingLeft: "2px",
+                        color: "rgba(40, 26, 26, 1)",
+                      }}
+                    >
+                      {this.state.game.Properties.Finished
+                        ? helpers.minutesToDuration(
+                            -this.state.game.Properties.FinishedAgo /
+                              1000000000 /
+                              60,
+                            true
+                          )
+                        : helpers.minutesToDuration(
+                            this.state.game.Properties.NewestPhaseMeta[0]
+                              .NextDeadlineIn /
+                              1000000000 /
+                              60,
+                            true
+                          )}
+                    </MaterialUI.Typography>
+                  </div>
+                </div>
+                <div key={itemKey++} className={secondRowSummaryClass}>
+                  <MaterialUI.Typography
+                    textroverflow="ellipsis"
+                    noWrap={true}
+                    display="inline"
+                    variant="caption"
+                    id="variant"
+                    className={secondRowSummaryColorClass}
+                  >
+                    {this.state.game.Properties.Variant}{" "}
+                    {helpers.phaseLengthDisplay(this.state.game.Properties)}
+                  </MaterialUI.Typography>
+                  <div className={summaryIconsAndPhaseClass}>
+                    <div className={summaryIconsClass}>{this.getIcons()}</div>
+                    <MaterialUI.Typography
+                      variant="caption"
+                      className={secondRowSummaryColorClass}
+                    >
+                      {this.state.game.Properties.NewestPhaseMeta[0].Season}{" "}
+                      {this.state.game.Properties.NewestPhaseMeta[0].Year},{" "}
+                      {this.state.game.Properties.NewestPhaseMeta[0].Type}
+                    </MaterialUI.Typography>
+                  </div>
+                </div>
+              </React.Fragment>
+            );
+          } else {
+            return (
+              <React.Fragment>
+                {/* IF STARTED */}
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <MaterialUI.Typography
+                    key={itemKey++}
+                    textroverflow="ellipsis"
+                    noWrap={true}
+                    style={{}}
+                  >
+                    {helpers.gameDesc(this.state.game)}
+                  </MaterialUI.Typography>
 
-				<div></div>
-			</div>
-		);
+                  <div
+                    id="Join"
+                    key={itemKey++}
+                    style={{
+                      alignSelf: "center",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    {helpers.createIcon("\ue7fb")}{" "}
+                    <MaterialUI.Typography
+                      variant="body2"
+                      style={{ paddingLeft: "2px" }}
+                    >
+                      {this.state.game.Properties.NMembers}/
+                      {this.variant.Properties.Nations.length}{" "}
+                    </MaterialUI.Typography>
+                  </div>
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <MaterialUI.Typography
+                    textroverflow="ellipsis"
+                    noWrap={true}
+                    display="inline"
+                    variant="caption"
+                    style={{
+                      color: "rgba(40, 26, 26, 0.7)",
+                    }}
+                  >
+                    {this.state.game.Properties.Variant}{" "}
+                    {helpers.phaseLengthDisplay(this.state.game.Properties)}
+                  </MaterialUI.Typography>
+                  <div> {this.getIcons()}</div>
+                </div>
+              </React.Fragment>
+            );
+          }
+        })()}
 
-		let gameView = (
-			<MaterialUI.Zoom
-				in={this.state.viewOpen}
-				mountOnEnter
-				unmountOnExit
-			>
-				<div
-					style={{
-						position: "fixed",
-						zIndex: 1300,
-						right: 0,
-						bottom: 0,
-						top: 0,
-						left: 0,
-						background: "#ffffff"
-					}}
-				>
-					<Game
-						onChangeReady={this.reloadGame}
-						onJoinGame={this.reloadGame}
-						onLeaveGame={_ => {
-							if (this.state.game.Properties.Members.length > 1) {
-								this.reloadGame();
-							} else {
-								this.dead = true;
-								this.forceUpdate();
-							}
-						}}
-						unreadMessagesUpdate={this.reloadGame}
-						gamePromise={reload => {
-							if (reload) {
-								return helpers
-									.safeFetch(
-										helpers.createRequest(
-											this.state.game.Links.find(l => {
-												return l.Rel == "self";
-											}).URL
-										)
-									)
-									.then(resp => resp.json());
-							} else {
-								return new Promise((res, rej) => {
-									res(this.state.game);
-								});
-							}
-						}}
-						close={this.closeGame}
-					/>
-				</div>
-			</MaterialUI.Zoom>
-		);
+        <div></div>
+      </div>
+    );
 
-		if (this.props.summaryOnly) {
-			return (
-				<React.Fragment>
-					<div style={{ width: "100%" }} onClick={this.viewGame}>
-						{summary}
-					</div>
-					{this.state.viewOpen ? gameView : ""}
-				</React.Fragment>
-			);
-		}
-		return (
-			<React.Fragment>
-				<MaterialUI.ExpansionPanel
-					key="game-details"
-					onChange={(ev, exp) => {
-						this.setState({ expanded: exp });
-					}}
-				>
-					{/* TODO: @Joren, the next iteration is here: styling the the expansionpanel on "My ..." list */}
-					<MaterialUI.ExpansionPanelSummary
-						classes={{
-							content: helpers.scopedClass("min-width: 0;")
-						}}
-						expandIcon={helpers.createIcon("\ue5cf")}
-					>
-						{summary}
-					</MaterialUI.ExpansionPanelSummary>
-					<MaterialUI.ExpansionPanelDetails style={{}}>
-						{this.state.expanded ? (
-							<div
-								style={{
-									display: "flex",
-									flexDirection: "row",
-									justifyContent: "space-between",
-									flexWrap: "wrap",
-									maxWidth: "960px",
-									width: "100%"
-								}}
-							>
-								<div
-									style={{
-										maxWidth: "460px"
-									}}
-								>
-									{expandedGameItems}
-								</div>
-								<div
-									style={{
-										width: "100%",
-										maxWidth: "460px"
-									}}
-								>
-									{playerList}
-								</div>
-							</div>
-						) : (
-							""
-						)}
-					</MaterialUI.ExpansionPanelDetails>
-				</MaterialUI.ExpansionPanel>
-				{this.state.viewOpen ? gameView : ""}
-				<NationPreferencesDialog
-					parentCB={c => {
-						this.nationPreferencesDialog = c;
-					}}
-					onSelected={null}
-				/>
-				{this.state.member ? (
-					<RenameGameDialog
-						onRename={this.reloadGame}
-						game={this.state.game}
-						parentCB={c => {
-							this.renameGameDialog = c;
-						}}
-					/>
-				) : (
-					""
-				)}
-			</React.Fragment>
-		);
-	}
+    let gameView = (
+      <MaterialUI.Zoom in={this.state.viewOpen} mountOnEnter unmountOnExit>
+        <div
+          style={{
+            position: "fixed",
+            zIndex: 1300,
+            right: 0,
+            bottom: 0,
+            top: 0,
+            left: 0,
+            background: "#ffffff",
+          }}
+        >
+          <Game
+            onChangeReady={this.reloadGame}
+            onJoinGame={this.reloadGame}
+            onLeaveGame={(_) => {
+              if (this.state.game.Properties.Members.length > 1) {
+                this.reloadGame();
+              } else {
+                this.dead = true;
+                this.forceUpdate();
+              }
+            }}
+            unreadMessagesUpdate={this.reloadGame}
+            gamePromise={(reload) => {
+              if (reload) {
+                return helpers
+                  .safeFetch(
+                    helpers.createRequest(
+                      this.state.game.Links.find((l) => {
+                        return l.Rel == "self";
+                      }).URL
+                    )
+                  )
+                  .then((resp) => resp.json());
+              } else {
+                return new Promise((res, rej) => {
+                  res(this.state.game);
+                });
+              }
+            }}
+            close={this.closeGame}
+          />
+        </div>
+      </MaterialUI.Zoom>
+    );
+
+    if (this.props.summaryOnly) {
+      return (
+        <React.Fragment>
+          <div style={{ width: "100%" }} onClick={this.viewGame}>
+            {summary}
+          </div>
+          {this.state.viewOpen ? gameView : ""}
+        </React.Fragment>
+      );
+    }
+    return (
+      <React.Fragment>
+        <MaterialUI.ExpansionPanel
+          key="game-details"
+          onChange={(ev, exp) => {
+            this.setState({ expanded: exp });
+          }}
+          square
+          style={{
+            border: "none",
+            boxShadow: "none",
+            padding: "0px",
+            margin: "0px",
+          }}
+        >
+          <MaterialUI.ExpansionPanelSummary
+            classes={{
+            	root: helpers.scopedClass("padding: 0px;"),
+              content: helpers.scopedClass("min-width: 0; margin: 0px;"),
+
+            }}
+            expandIcon={helpers.createIcon("\ue5cf")}
+          >
+            {summary}
+          </MaterialUI.ExpansionPanelSummary>
+          <MaterialUI.ExpansionPanelDetails 
+           classes={{
+            	root: helpers.scopedClass("padding: 0px;"),
+              content: helpers.scopedClass("min-width: 0; "),
+
+            }}>
+            {this.state.expanded ? (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  flexWrap: "wrap",
+                  maxWidth: "960px",
+                  width: "100%",
+                }}
+              >
+                <div
+                  style={{
+                    maxWidth: "460px",
+                  }}
+                >
+                  {expandedGameItems}
+                </div>
+                <div
+                  style={{
+                    width: "100%",
+                    maxWidth: "460px",
+                  }}
+                >
+                  {playerList}
+                </div>
+              </div>
+            ) : (
+              ""
+            )}
+          </MaterialUI.ExpansionPanelDetails>
+        </MaterialUI.ExpansionPanel>
+        {this.state.viewOpen ? gameView : ""}
+        <NationPreferencesDialog
+          parentCB={(c) => {
+            this.nationPreferencesDialog = c;
+          }}
+          onSelected={null}
+        />
+        {this.state.member ? (
+          <RenameGameDialog
+            onRename={this.reloadGame}
+            game={this.state.game}
+            parentCB={(c) => {
+              this.renameGameDialog = c;
+            }}
+          />
+        ) : (
+          ""
+        )}
+      </React.Fragment>
+    );
+  }
 }

--- a/resources/js/game_players.js
+++ b/resources/js/game_players.js
@@ -138,6 +138,7 @@ export default class GameMetadata extends React.Component {
         >
           <MaterialUI.DialogTitle>Players</MaterialUI.DialogTitle>
           <MaterialUI.DialogContent>
+          <MaterialUI.Typography variant="subtitle2" style={{paddingBottom: "8px"}}>Banning a player means you'll never play with them again.</MaterialUI.Typography>  
             {this.state.gameStates
               ? this.props.game.Properties.Members.map((member) => {
                   return (

--- a/resources/js/main_menu.js
+++ b/resources/js/main_menu.js
@@ -10,202 +10,216 @@ import ErrorsDialog from '%{ cb "/js/errors_dialog.js" }%';
 import StatsDialog from '%{ cb "/js/stats_dialog.js" }%';
 
 export default class MainMenu extends ActivityContainer {
-  constructor(props) {
-    super(props);
-    this.openDrawer = this.openDrawer.bind(this);
-    this.closeDrawer = this.closeDrawer.bind(this);
-    this.renderGameList = this.renderGameList.bind(this);
-    this.findGameByID = this.findGameByID.bind(this);
-    this.renderOpenGames = this.renderOpenGames.bind(this);
-    this.renderMyStagingGames = this.renderMyStagingGames.bind(this);
-    this.state = {
-      drawerOpen: false,
-      activity: Start,
-      statsDialogOpen: false,
-      activityProps: {
-        urls: this.props.urls,
-        findPrivateGame: this.findGameByID,
-        findOpenGame: this.renderOpenGames,
-        myStagingGames: this.renderMyStagingGames,
-      },
-    };
-    this.findGameDialog = null;
-    this.settingsDialog = null;
-    this.errorsDialog = null;
-    helpers.urlMatch(
-      [
-        [
-          /^\/Game\/([^\/]+)/,
-          (match) => {
-            this.state.activity = Game;
-            this.state.activityProps = {
-              gamePromise: (_) => {
-                return helpers
-                  .safeFetch(helpers.createRequest("/Game/" + match[1]))
-                  .then((resp) => resp.json());
-              },
-              close: (_) => {
-                this.setActivity(Start, {
-                  urls: this.props.urls,
-                  findPrivateGame: this.findGameByID,
-                  findOpenGame: this.renderOpenGames,
-                  myStagingGames: this.renderMyStagingGames,
-                });
-              },
-            };
-          },
-        ],
-      ],
-      (_) => {
-        history.pushState("", "", "/");
-      }
-    );
-  }
-  componentDidMount() {
-    gtag("set", {
-      page_title: "MainMenu",
-      page_location: location.href,
-    });
-    gtag("event", "page_view");
-  }
-  findGameByID() {
-    this.findGameDialog.setState({
-      open: true,
-      onFind: (gameID) => {
-        if (gameID == "") {
-          return;
-        }
-        const match = /\/Game\/([^/]+)/.exec(gameID);
-        if (match) {
-          gameID = match[1];
-        }
-        helpers
-          .safeFetch(helpers.createRequest("/Game/" + gameID))
-          .then((resp) => {
-            if (resp.status == 200) {
-              resp.json().then((js) => {
-                this.setState({
-                  activity: GameList,
-                  activityProps: {
-                    label: gameID,
-                    key: "predefined-game-list",
-                    predefinedList: [js],
-                  },
-                });
-              });
-            } else {
-              helpers.snackbar("Didn't find a game with ID " + gameID);
-            }
-          });
-      },
-    });
-  }
-  openDrawer() {
-    this.setState({ drawerOpen: true });
-  }
-  closeDrawer() {
-    this.setState({ drawerOpen: false });
-  }
-  renderMyStagingGames() {
-    this.setActivity(GameList, {
-      label: "My staging games",
-      key: "my-staging-games",
-      url: this.props.urls["my-staging-games"],
-    });
-  }
-  renderOpenGames() {
-    this.setActivity(GameList, {
-      key: "open-games",
-      label: "Open games",
-      url: this.props.urls["open-games"],
-    });
-  }
-  renderGameList(ev) {
-    this.setActivity(GameList, {
-      label: ev.currentTarget.getAttribute("label"),
-      key: ev.currentTarget.getAttribute("urlkey"),
-      url: this.props.urls[ev.currentTarget.getAttribute("urlkey")],
-    });
-  }
-  render() {
-    return (
-      <React.Fragment>
-        <MaterialUI.AppBar position="fixed">
-          <MaterialUI.Toolbar>
-            <MaterialUI.IconButton
-              edge="start"
-              onClick={this.openDrawer}
-              color="secondary"
-            >
-              {helpers.createIcon("\ue5d2")}
-            </MaterialUI.IconButton>
-            <MaterialUI.Typography
-              style={{ flexGrow: 1 }}
-            ></MaterialUI.Typography>
-            <MaterialUI.IconButton
-              edge="end"
-              onClick={(ev) => {
-                this.setState({
-                  menuAnchorEl: ev.currentTarget,
-                });
-              }}
-              color="secondary"
-            >
-              <MaterialUI.Avatar
-                alt="test"
-                src={Globals.user.Picture}
-                style={{
-                  width: "32px",
-                  height: "32px",
-                  border: "1px solid #FDE2B5",
-                }}
-              />
-            </MaterialUI.IconButton>
-            <MaterialUI.Menu
-              anchorEl={this.state.menuAnchorEl}
-              anchorOrigin={{
-                vertical: "top",
-                horizontal: "right",
-              }}
-              transformOrigin={{
-                vertical: "top",
-                horizontal: "right",
-              }}
-              onClose={(_) => {
-                this.setState({ menuAnchorEl: null });
-              }}
-              open={!!this.state.menuAnchorEl}
-            >
-              <MaterialUI.MenuItem
-                key="stats"
-                onClick={(_) => {
-                  this.setState({
-                    menuAnchorEl: null,
-                    statsDialogOpen: true,
-                  });
-                }}
-              >
-                Player stats
-              </MaterialUI.MenuItem>
+	constructor(props) {
+		super(props);
+		this.openDrawer = this.openDrawer.bind(this);
+		this.closeDrawer = this.closeDrawer.bind(this);
+		this.renderGameList = this.renderGameList.bind(this);
+		this.findGameByID = this.findGameByID.bind(this);
+		this.renderOpenGames = this.renderOpenGames.bind(this);
+		this.renderMyStagingGames = this.renderMyStagingGames.bind(this);
+		this.state = {
+			drawerOpen: false,
+			activity: Start,
+			statsDialogOpen: false,
+			activityProps: {
+				urls: this.props.urls,
+				findPrivateGame: this.findGameByID,
+				findOpenGame: this.renderOpenGames,
+				myStagingGames: this.renderMyStagingGames
+			}
+		};
+		this.findGameDialog = null;
+		this.settingsDialog = null;
+		this.errorsDialog = null;
+		helpers.urlMatch(
+			[
+				[
+					/^\/Game\/([^\/]+)/,
+					match => {
+						this.state.activity = Game;
+						this.state.activityProps = {
+							gamePromise: _ => {
+								return helpers
+									.safeFetch(
+										helpers.createRequest(
+											"/Game/" + match[1]
+										)
+									)
+									.then(resp => resp.json());
+							},
+							close: _ => {
+								this.setActivity(Start, {
+									urls: this.props.urls,
+									findPrivateGame: this.findGameByID,
+									findOpenGame: this.renderOpenGames,
+									myStagingGames: this.renderMyStagingGames
+								});
+							}
+						};
+					}
+				]
+			],
+			_ => {
+				history.pushState("", "", "/");
+			}
+		);
+	}
+	componentDidMount() {
+		gtag("set", {
+			page_title: "MainMenu",
+			page_location: location.href
+		});
+		gtag("event", "page_view");
+	}
+	findGameByID() {
+		this.findGameDialog.setState({
+			open: true,
+			onFind: gameID => {
+				if (gameID == "") {
+					return;
+				}
+				const match = /\/Game\/([^/]+)/.exec(gameID);
+				if (match) {
+					gameID = match[1];
+				}
+				helpers
+					.safeFetch(helpers.createRequest("/Game/" + gameID))
+					.then(resp => {
+						if (resp.status == 200) {
+							resp.json().then(js => {
+								this.setState({
+									activity: GameList,
+									activityProps: {
+										label: gameID,
+										key: "predefined-game-list",
+										predefinedList: [js]
+									}
+								});
+							});
+						} else {
+							helpers.snackbar(
+								"Didn't find a game with ID " + gameID
+							);
+						}
+					});
+			}
+		});
+	}
+	openDrawer() {
+		this.setState({ drawerOpen: true });
+	}
+	closeDrawer() {
+		this.setState({ drawerOpen: false });
+	}
+	renderMyStagingGames() {
+		this.setActivity(GameList, {
+			label: "My staging games",
+			key: "my-staging-games",
+			url: this.props.urls["my-staging-games"]
+		});
+	}
+	renderOpenGames() {
+		this.setActivity(GameList, {
+			key: "open-games",
+			label: "Open games",
+			url: this.props.urls["open-games"]
+		});
+	}
+	renderGameList(ev) {
+		this.setActivity(GameList, {
+			label: ev.currentTarget.getAttribute("label"),
+			key: ev.currentTarget.getAttribute("urlkey"),
+			url: this.props.urls[ev.currentTarget.getAttribute("urlkey")]
+		});
+	}
+	render() {
+		return (
+			<React.Fragment>
+				<MaterialUI.AppBar position="fixed">
+					<MaterialUI.Toolbar>
+						<MaterialUI.IconButton
+							edge="start"
+							onClick={this.openDrawer}
+							color="secondary"
+						>
+							{helpers.createIcon("\ue5d2")}
+						</MaterialUI.IconButton>
+						<MaterialUI.Typography
+							style={{ flexGrow: 1 }}
+						></MaterialUI.Typography>
+						<MaterialUI.IconButton
+							edge="end"
+							onClick={ev => {
+								this.setState({
+									menuAnchorEl: ev.currentTarget
+								});
+							}}
+							color="secondary"
+						>
+							<MaterialUI.Avatar
+								alt="test"
+								src={Globals.user.Picture}
+								style={{
+									width: "32px",
+									height: "32px",
+									border: "1px solid #FDE2B5"
+								}}
+							/>
+						</MaterialUI.IconButton>
+						<MaterialUI.Menu
+							anchorEl={this.state.menuAnchorEl}
+							anchorOrigin={{
+								vertical: "top",
+								horizontal: "right"
+							}}
+							transformOrigin={{
+								vertical: "top",
+								horizontal: "right"
+							}}
+							onClose={_ => {
+								this.setState({ menuAnchorEl: null });
+							}}
+							open={!!this.state.menuAnchorEl}
+						>
+							<MaterialUI.MenuItem
+								key="stats"
+								onClick={_ => {
+									this.setState({
+										menuAnchorEl: null,
+										statsDialogOpen: true
+									});
+								}}
+							>
+								Player stats
+							</MaterialUI.MenuItem>
 
-              <MaterialUI.MenuItem key="logout" onClick={helpers.logout}>
-                Logout
-              </MaterialUI.MenuItem>
-            </MaterialUI.Menu>
-          </MaterialUI.Toolbar>
-        </MaterialUI.AppBar>
-        <div style={{ marginTop: "60px" }}>{this.renderActivity()}</div>
-        <MaterialUI.Drawer open={this.state.drawerOpen}>
-          <MaterialUI.ClickAwayListener onClickAway={this.closeDrawer}>
-            <div onClick={this.closeDrawer}>
-              <MaterialUI.List component="nav">
-                <MaterialUI.ListItem
-                  style={{ padding: "24px 16px 8px 16px", height: "40px" }}
-                >
-                  <MaterialUI.ListItemText
-                    primary="My Diplicity"
-                    disableTypography
-                    className={helpers.scopedClass(`
+							<MaterialUI.MenuItem
+								key="logout"
+								onClick={helpers.logout}
+							>
+								Logout
+							</MaterialUI.MenuItem>
+						</MaterialUI.Menu>
+					</MaterialUI.Toolbar>
+				</MaterialUI.AppBar>
+				<div style={{ marginTop: "60px" }}>{this.renderActivity()}</div>
+				<MaterialUI.Drawer open={this.state.drawerOpen}>
+					<MaterialUI.ClickAwayListener
+						onClickAway={this.closeDrawer}
+					>
+						<div onClick={this.closeDrawer}>
+							<MaterialUI.List component="nav">
+								<MaterialUI.ListItem
+									style={{
+										padding: "24px 16px 8px 16px",
+										height: "40px"
+									}}
+								>
+									<MaterialUI.ListItemText
+										primary="My Diplicity"
+										disableTypography
+										className={helpers.scopedClass(`
     color: rgba(40, 26, 26, 0.56);
     min-height: auto;
     min-width: auto;
@@ -213,36 +227,37 @@ export default class MainMenu extends ActivityContainer {
     margin: 0px 0px 2px;
 
               	`)}
-                  />
-                </MaterialUI.ListItem>
+									/>
+								</MaterialUI.ListItem>
 
-                <MaterialUI.ListItem
-                  button
-                  onClick={(_) => {
-                    this.setActivity(Start, {
-                      urls: this.props.urls,
-                      findPrivateGame: this.findGameByID,
-                      findOpenGame: this.renderOpenGames,
-                      myStagingGames: this.renderMyStagingGames,
-                    });
-                  }}
-                >
-                  <MaterialUI.ListItemText primary="My games" />
-                </MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									button
+									onClick={_ => {
+										this.setActivity(Start, {
+											urls: this.props.urls,
+											findPrivateGame: this.findGameByID,
+											findOpenGame: this.renderOpenGames,
+											myStagingGames: this
+												.renderMyStagingGames
+										});
+									}}
+								>
+									<MaterialUI.ListItemText primary="My games" />
+								</MaterialUI.ListItem>
 
-                <MaterialUI.ListItem
-                  button
-                  onClick={(_) => {
-                    this.setState({ menuAnchorEl: null });
-                    this.settingsDialog.setState({
-                      open: true,
-                    });
-                  }}
-                >
-                  <MaterialUI.ListItemText primary="Settings" />
-                </MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									button
+									onClick={_ => {
+										this.setState({ menuAnchorEl: null });
+										this.settingsDialog.setState({
+											open: true
+										});
+									}}
+								>
+									<MaterialUI.ListItemText primary="Settings" />
+								</MaterialUI.ListItem>
 
-                {/* TODO: make sure these are in the "view more"
+								{/* TODO: make sure these are in the "view more"
                 <MaterialUI.ListItem
                   button
                   urlkey="my-started-games"
@@ -268,15 +283,18 @@ export default class MainMenu extends ActivityContainer {
                   <MaterialUI.ListItemText primary="My finished games" />
                 </MaterialUI.ListItem>
             */}
-                <MaterialUI.Divider />
+								<MaterialUI.Divider />
 
-                <MaterialUI.ListItem
-                  style={{ padding: "24px 16px 8px 16px", height: "40px" }}
-                >
-                  <MaterialUI.ListItemText
-                    primary="Public games"
-                    disableTypography
-                    className={helpers.scopedClass(`
+								<MaterialUI.ListItem
+									style={{
+										padding: "24px 16px 8px 16px",
+										height: "40px"
+									}}
+								>
+									<MaterialUI.ListItemText
+										primary="Public games"
+										disableTypography
+										className={helpers.scopedClass(`
     color: rgba(40, 26, 26, 0.56);
     min-height: auto;
     min-width: auto;
@@ -284,43 +302,46 @@ export default class MainMenu extends ActivityContainer {
     margin: 0px 0px 2px;
 
               	`)}
-                  />
-                </MaterialUI.ListItem>
+									/>
+								</MaterialUI.ListItem>
 
-                <MaterialUI.ListItem
-                  button
-                  urlkey="open-games"
-                  label="Open games"
-                  onClick={this.renderGameList}
-                >
-                  <MaterialUI.ListItemText primary="Open games" />
-                </MaterialUI.ListItem>
-                <MaterialUI.ListItem
-                  style={{ padding: "4px 16px" }}
-                  button
-                  urlkey="started-games"
-                  label="Started games"
-                  onClick={this.renderGameList}
-                >
-                  <MaterialUI.ListItemText primary="Started games" />
-                </MaterialUI.ListItem>
-                <MaterialUI.ListItem
-                  button
-                  urlkey="finished-games"
-                  label="Finished games"
-                  onClick={this.renderGameList}
-                >
-                  <MaterialUI.ListItemText primary="Finished games" />
-                </MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									button
+									urlkey="open-games"
+									label="Open games"
+									onClick={this.renderGameList}
+								>
+									<MaterialUI.ListItemText primary="Open games" />
+								</MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									style={{ padding: "4px 16px" }}
+									button
+									urlkey="started-games"
+									label="Started games"
+									onClick={this.renderGameList}
+								>
+									<MaterialUI.ListItemText primary="Started games" />
+								</MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									button
+									urlkey="finished-games"
+									label="Finished games"
+									onClick={this.renderGameList}
+								>
+									<MaterialUI.ListItemText primary="Finished games" />
+								</MaterialUI.ListItem>
 
-                <MaterialUI.Divider />
-                <MaterialUI.ListItem
-                  style={{ padding: "24px 16px 8px 16px", height: "40px" }}
-                >
-                  <MaterialUI.ListItemText
-                    primary="Community"
-                    disableTypography
-                    className={helpers.scopedClass(`
+								<MaterialUI.Divider />
+								<MaterialUI.ListItem
+									style={{
+										padding: "24px 16px 8px 16px",
+										height: "40px"
+									}}
+								>
+									<MaterialUI.ListItemText
+										primary="Community"
+										disableTypography
+										className={helpers.scopedClass(`
     color: rgba(40, 26, 26, 0.56);
     min-height: auto;
     min-width: auto;
@@ -328,42 +349,44 @@ export default class MainMenu extends ActivityContainer {
     margin: 0px 0px 2px;
 
               	`)}
-                  />
-                </MaterialUI.ListItem>
+									/>
+								</MaterialUI.ListItem>
 
-                <MaterialUI.ListItem
-                  button
-                  onClick={(_) => {
-                    open("https://discord.gg/bu3JxYc");
-                  }}
-                >
-                  <MaterialUI.ListItemText primary="Chat" />
-                </MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									button
+									onClick={_ => {
+										open("https://discord.gg/bu3JxYc");
+									}}
+								>
+									<MaterialUI.ListItemText primary="Chat" />
+								</MaterialUI.ListItem>
 
-                <MaterialUI.ListItem
-                  style={{ padding: "4px 16px" }}
-                  button
-                  onClick={(_) => {
-                    open(
-                      "https://groups.google.com/forum/#!forum/diplicity-talk"
-                    );
-                  }}
-                >
-                  <MaterialUI.ListItemText primary="Forum" />
-                </MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									style={{ padding: "4px 16px" }}
+									button
+									onClick={_ => {
+										open(
+											"https://groups.google.com/forum/#!forum/diplicity-talk"
+										);
+									}}
+								>
+									<MaterialUI.ListItemText primary="Forum" />
+								</MaterialUI.ListItem>
 
-                <MaterialUI.ListItem
-                  button
-                  onClick={(_) => {
-                    open("https://sites.google.com/corp/view/diplicity");
-                  }}
-                >
-                  <MaterialUI.ListItemText primary="Help" />
-                </MaterialUI.ListItem>
+								<MaterialUI.ListItem
+									button
+									onClick={_ => {
+										open(
+											"https://sites.google.com/corp/view/diplicity"
+										);
+									}}
+								>
+									<MaterialUI.ListItemText primary="Help" />
+								</MaterialUI.ListItem>
 
-                <MaterialUI.Divider />
+								<MaterialUI.Divider />
 
-                {/* 
+								{/* 
                 <MaterialUI.ListItem
                   button
                   onClick={(_) => {
@@ -376,61 +399,75 @@ export default class MainMenu extends ActivityContainer {
                 </MaterialUI.ListItem>
 
             */}
-              </MaterialUI.List>
-              <div
-                style={{ width: "calc(100% - 16px)", display: "Flex", justifyContent: "space-around", padding: "0px 8px" }}
-              >
-                <div id="github" style={{padding: "8px"}} 
-                                  onClick={(_) => {
-                    open("https://github.com/zond/dipact");
-                  }}>
-                  <MaterialUI.SvgIcon>
-                    <path
-                      fill="#281A1A"
-                      d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
-                    />
-                  </MaterialUI.SvgIcon>
-                </div>
-                <div id="errorlog"  style={{padding: "8px"}}
-                onClick={(_) => {
-                    this.closeDrawer;
-                    this.errorsDialog.setState({ open: true });
-                  }}>
-                {helpers.createIcon("\ue868")}</div>
-              </div>
-            </div>
-          </MaterialUI.ClickAwayListener>
-        </MaterialUI.Drawer>
-        <FindGameDialog
-          parentCB={(c) => {
-            this.findGameDialog = c;
-          }}
-          key="find-game-dialog"
-        />
-        <SettingsDialog
-          key="settings-dialog"
-          parentCB={(c) => {
-            this.settingsDialog = c;
-          }}
-        />
-        <ErrorsDialog
-          key="errors-dialog"
-          parentCB={(c) => {
-            this.errorsDialog = c;
-          }}
-        />
-        {this.state.statsDialogOpen ? (
-          <StatsDialog
-            open={this.state.statsDialogOpen}
-            user={Globals.user}
-            onClose={(_) => {
-              this.setState({ statsDialogOpen: false });
-            }}
-          />
-        ) : (
-          ""
-        )}
-      </React.Fragment>
-    );
-  }
+							</MaterialUI.List>
+							<div
+								style={{
+									width: "calc(100% - 16px)",
+									display: "Flex",
+									justifyContent: "space-around",
+									padding: "0px 8px"
+								}}
+							>
+								<div
+									id="github"
+									style={{ padding: "8px" }}
+									onClick={_ => {
+										open("https://github.com/zond/dipact");
+									}}
+								>
+									<MaterialUI.SvgIcon>
+										<path
+											fill="#281A1A"
+											d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+										/>
+									</MaterialUI.SvgIcon>
+								</div>
+								<div
+									id="errorlog"
+									style={{ padding: "8px" }}
+									onClick={_ => {
+										this.closeDrawer;
+										this.errorsDialog.setState({
+											open: true
+										});
+									}}
+								>
+									{helpers.createIcon("\ue868")}
+								</div>
+							</div>
+						</div>
+					</MaterialUI.ClickAwayListener>
+				</MaterialUI.Drawer>
+				<FindGameDialog
+					parentCB={c => {
+						this.findGameDialog = c;
+					}}
+					key="find-game-dialog"
+				/>
+				<SettingsDialog
+					key="settings-dialog"
+					parentCB={c => {
+						this.settingsDialog = c;
+					}}
+				/>
+				<ErrorsDialog
+					key="errors-dialog"
+					parentCB={c => {
+						this.errorsDialog = c;
+					}}
+				/>
+				{this.state.statsDialogOpen ? (
+					<StatsDialog
+						open={this.state.statsDialogOpen}
+						user={Globals.user}
+						onClose={_ => {
+							this.setState({ statsDialogOpen: false });
+						}}
+					/>
+				) : (
+					""
+				)}
+			</React.Fragment>
+		);
+	}
 }

--- a/resources/js/main_menu.js
+++ b/resources/js/main_menu.js
@@ -156,8 +156,9 @@ export default class MainMenu extends ActivityContainer {
 								});
 							}}
 							color="secondary"
-						>
-							{helpers.createIcon("\ue853")}
+						>	
+							<MaterialUI.Avatar alt="test" src={Globals.user.Picture} style={{width: "32px", height: "32px", border:"1px solid #FDE2B5"}} />
+						
 						</MaterialUI.IconButton>
 						<MaterialUI.Menu
 							anchorEl={this.state.menuAnchorEl}

--- a/resources/js/main_menu.js
+++ b/resources/js/main_menu.js
@@ -10,358 +10,427 @@ import ErrorsDialog from '%{ cb "/js/errors_dialog.js" }%';
 import StatsDialog from '%{ cb "/js/stats_dialog.js" }%';
 
 export default class MainMenu extends ActivityContainer {
-	constructor(props) {
-		super(props);
-		this.openDrawer = this.openDrawer.bind(this);
-		this.closeDrawer = this.closeDrawer.bind(this);
-		this.renderGameList = this.renderGameList.bind(this);
-		this.findGameByID = this.findGameByID.bind(this);
-		this.renderOpenGames = this.renderOpenGames.bind(this);
-		this.renderMyStagingGames = this.renderMyStagingGames.bind(this);
-		this.state = {
-			drawerOpen: false,
-			activity: Start,
-			statsDialogOpen: false,
-			activityProps: {
-				urls: this.props.urls,
-				findPrivateGame: this.findGameByID,
-				findOpenGame: this.renderOpenGames,
-				myStagingGames: this.renderMyStagingGames
-			}
-		};
-		this.findGameDialog = null;
-		this.settingsDialog = null;
-		this.errorsDialog = null;
-		helpers.urlMatch(
-			[
-				[
-					/^\/Game\/([^\/]+)/,
-					match => {
-						this.state.activity = Game;
-						this.state.activityProps = {
-							gamePromise: _ => {
-								return helpers
-									.safeFetch(
-										helpers.createRequest(
-											"/Game/" + match[1]
-										)
-									)
-									.then(resp => resp.json());
-							},
-							close: _ => {
-								this.setActivity(Start, {
-									urls: this.props.urls,
-									findPrivateGame: this.findGameByID,
-									findOpenGame: this.renderOpenGames,
-									myStagingGames: this.renderMyStagingGames
-								});
-							}
-						};
-					}
-				]
-			],
-			_ => {
-				history.pushState("", "", "/");
-			}
-		);
-	}
-	componentDidMount() {
-		gtag("set", {
-			page_title: "MainMenu",
-			page_location: location.href
-		});
-		gtag("event", "page_view");
-	}
-	findGameByID() {
-		this.findGameDialog.setState({
-			open: true,
-			onFind: gameID => {
-				if (gameID == "") {
-					return;
-				}
-				const match = /\/Game\/([^/]+)/.exec(gameID);
-				if (match) {
-					gameID = match[1];
-				}
-				helpers
-					.safeFetch(helpers.createRequest("/Game/" + gameID))
-					.then(resp => {
-						if (resp.status == 200) {
-							resp.json().then(js => {
-								this.setState({
-									activity: GameList,
-									activityProps: {
-										label: gameID,
-										key: "predefined-game-list",
-										predefinedList: [js]
-									}
-								});
-							});
-						} else {
-							helpers.snackbar(
-								"Didn't find a game with ID " + gameID
-							);
-						}
-					});
-			}
-		});
-	}
-	openDrawer() {
-		this.setState({ drawerOpen: true });
-	}
-	closeDrawer() {
-		this.setState({ drawerOpen: false });
-	}
-	renderMyStagingGames() {
-		this.setActivity(GameList, {
-			label: "My staging games",
-			key: "my-staging-games",
-			url: this.props.urls["my-staging-games"]
-		});
-	}
-	renderOpenGames() {
-		this.setActivity(GameList, {
-			key: "open-games",
-			label: "Open games",
-			url: this.props.urls["open-games"]
-		});
-	}
-	renderGameList(ev) {
-		this.setActivity(GameList, {
-			label: ev.currentTarget.getAttribute("label"),
-			key: ev.currentTarget.getAttribute("urlkey"),
-			url: this.props.urls[ev.currentTarget.getAttribute("urlkey")]
-		});
-	}
-	render() {
-		return (
-			<React.Fragment>
-				<MaterialUI.AppBar position="fixed">
-					<MaterialUI.Toolbar>
-						<MaterialUI.IconButton
-							edge="start"
-							onClick={this.openDrawer}
-							color="secondary"
-						>
-							{helpers.createIcon("\ue5d2")}
-						</MaterialUI.IconButton>
-						<MaterialUI.Typography
-							style={{ flexGrow: 1 }}
-						></MaterialUI.Typography>
-						<MaterialUI.IconButton
-							edge="end"
-							onClick={ev => {
-								this.setState({
-									menuAnchorEl: ev.currentTarget
-								});
-							}}
-							color="secondary"
-						>	
-							<MaterialUI.Avatar alt="test" src={Globals.user.Picture} style={{width: "32px", height: "32px", border:"1px solid #FDE2B5"}} />
-						
-						</MaterialUI.IconButton>
-						<MaterialUI.Menu
-							anchorEl={this.state.menuAnchorEl}
-							anchorOrigin={{
-								vertical: "top",
-								horizontal: "right"
-							}}
-							transformOrigin={{
-								vertical: "top",
-								horizontal: "right"
-							}}
-							onClose={_ => {
-								this.setState({ menuAnchorEl: null });
-							}}
-							open={!!this.state.menuAnchorEl}
-						>
-							<MaterialUI.MenuItem
-								key="settings"
-								onClick={_ => {
-									this.setState({ menuAnchorEl: null });
-									this.settingsDialog.setState({
-										open: true
-									});
-								}}
-							>
-								Settings
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="stats"
-								onClick={_ => {
-									this.setState({
-										menuAnchorEl: null,
-										statsDialogOpen: true
-									});
-								}}
-							>
-								Stats
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="help-wiki"
-								onClick={_ => {
-									open(
-										"https://sites.google.com/corp/view/diplicity"
-									);
-								}}
-							>
-								Help
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="forum"
-								onClick={_ => {
-									open(
-										"https://groups.google.com/forum/#!forum/diplicity-talk"
-									);
-								}}
-							>
-								Forum
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="chat"
-								onClick={_ => {
-									open("https://discord.gg/bu3JxYc");
-								}}
-							>
-								Chat
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="source"
-								onClick={_ => {
-									open("https://github.com/zond/dipact");
-								}}
-							>
-								Source code
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="errors"
-								onClick={_ => {
-									this.setState({
-										menuAnchorEl: null
-									});
-									this.errorsDialog.setState({ open: true });
-								}}
-							>
-								Error log
-							</MaterialUI.MenuItem>
-							<MaterialUI.MenuItem
-								key="logout"
-								onClick={helpers.logout}
-							>
-								Logout
-							</MaterialUI.MenuItem>
-						</MaterialUI.Menu>
-					</MaterialUI.Toolbar>
-				</MaterialUI.AppBar>
-				<div style={{ marginTop: "60px" }}>{this.renderActivity()}</div>
-				<MaterialUI.Drawer open={this.state.drawerOpen}>
-					<MaterialUI.ClickAwayListener
-						onClickAway={this.closeDrawer}
-					>
-						<div onClick={this.closeDrawer}>
-							<MaterialUI.List component="nav">
-								<MaterialUI.ListItem
-									button
-									onClick={_ => {
-										this.setActivity(Start, {
-											urls: this.props.urls,
-											findPrivateGame: this.findGameByID,
-											findOpenGame: this.renderOpenGames,
-											myStagingGames: this
-												.renderMyStagingGames
-										});
-									}}
-								>
-									<MaterialUI.ListItemText primary="Start" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									urlkey="my-started-games"
-									label="My started games"
-									onClick={this.renderGameList}
-								>
-									<MaterialUI.ListItemText primary="My started games" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									urlkey="my-staging-games"
-									label="My staging games"
-									onClick={this.renderGameList}
-								>
-									<MaterialUI.ListItemText primary="My staging games" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									urlkey="my-finished-games"
-									label="My finished games"
-									onClick={this.renderGameList}
-								>
-									<MaterialUI.ListItemText primary="My finished games" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									urlkey="open-games"
-									label="Open games"
-									onClick={this.renderGameList}
-								>
-									<MaterialUI.ListItemText primary="Open games" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									urlkey="started-games"
-									label="Started games"
-									onClick={this.renderGameList}
-								>
-									<MaterialUI.ListItemText primary="Started games" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									urlkey="finished-games"
-									label="Finished games"
-									onClick={this.renderGameList}
-								>
-									<MaterialUI.ListItemText primary="Finished games" />
-								</MaterialUI.ListItem>
-								<MaterialUI.ListItem
-									button
-									onClick={this.findGameByID}
-								>
-									<MaterialUI.ListItemText primary="Lookup game" />
-								</MaterialUI.ListItem>
-							</MaterialUI.List>
-						</div>
-					</MaterialUI.ClickAwayListener>
-				</MaterialUI.Drawer>
-				<FindGameDialog
-					parentCB={c => {
-						this.findGameDialog = c;
-					}}
-					key="find-game-dialog"
-				/>
-				<SettingsDialog
-					key="settings-dialog"
-					parentCB={c => {
-						this.settingsDialog = c;
-					}}
-				/>
-				<ErrorsDialog
-					key="errors-dialog"
-					parentCB={c => {
-						this.errorsDialog = c;
-					}}
-				/>
-				{this.state.statsDialogOpen ? (
-					<StatsDialog
-						open={this.state.statsDialogOpen}
-						user={Globals.user}
-						onClose={_ => {
-							this.setState({ statsDialogOpen: false });
-						}}
-					/>
-				) : (
-					""
-				)}
-			</React.Fragment>
-		);
-	}
+  constructor(props) {
+    super(props);
+    this.openDrawer = this.openDrawer.bind(this);
+    this.closeDrawer = this.closeDrawer.bind(this);
+    this.renderGameList = this.renderGameList.bind(this);
+    this.findGameByID = this.findGameByID.bind(this);
+    this.renderOpenGames = this.renderOpenGames.bind(this);
+    this.renderMyStagingGames = this.renderMyStagingGames.bind(this);
+    this.state = {
+      drawerOpen: false,
+      activity: Start,
+      statsDialogOpen: false,
+      activityProps: {
+        urls: this.props.urls,
+        findPrivateGame: this.findGameByID,
+        findOpenGame: this.renderOpenGames,
+        myStagingGames: this.renderMyStagingGames,
+      },
+    };
+    this.findGameDialog = null;
+    this.settingsDialog = null;
+    this.errorsDialog = null;
+    helpers.urlMatch(
+      [
+        [
+          /^\/Game\/([^\/]+)/,
+          (match) => {
+            this.state.activity = Game;
+            this.state.activityProps = {
+              gamePromise: (_) => {
+                return helpers
+                  .safeFetch(helpers.createRequest("/Game/" + match[1]))
+                  .then((resp) => resp.json());
+              },
+              close: (_) => {
+                this.setActivity(Start, {
+                  urls: this.props.urls,
+                  findPrivateGame: this.findGameByID,
+                  findOpenGame: this.renderOpenGames,
+                  myStagingGames: this.renderMyStagingGames,
+                });
+              },
+            };
+          },
+        ],
+      ],
+      (_) => {
+        history.pushState("", "", "/");
+      }
+    );
+  }
+  componentDidMount() {
+    gtag("set", {
+      page_title: "MainMenu",
+      page_location: location.href,
+    });
+    gtag("event", "page_view");
+  }
+  findGameByID() {
+    this.findGameDialog.setState({
+      open: true,
+      onFind: (gameID) => {
+        if (gameID == "") {
+          return;
+        }
+        const match = /\/Game\/([^/]+)/.exec(gameID);
+        if (match) {
+          gameID = match[1];
+        }
+        helpers
+          .safeFetch(helpers.createRequest("/Game/" + gameID))
+          .then((resp) => {
+            if (resp.status == 200) {
+              resp.json().then((js) => {
+                this.setState({
+                  activity: GameList,
+                  activityProps: {
+                    label: gameID,
+                    key: "predefined-game-list",
+                    predefinedList: [js],
+                  },
+                });
+              });
+            } else {
+              helpers.snackbar("Didn't find a game with ID " + gameID);
+            }
+          });
+      },
+    });
+  }
+  openDrawer() {
+    this.setState({ drawerOpen: true });
+  }
+  closeDrawer() {
+    this.setState({ drawerOpen: false });
+  }
+  renderMyStagingGames() {
+    this.setActivity(GameList, {
+      label: "My staging games",
+      key: "my-staging-games",
+      url: this.props.urls["my-staging-games"],
+    });
+  }
+  renderOpenGames() {
+    this.setActivity(GameList, {
+      key: "open-games",
+      label: "Open games",
+      url: this.props.urls["open-games"],
+    });
+  }
+  renderGameList(ev) {
+    this.setActivity(GameList, {
+      label: ev.currentTarget.getAttribute("label"),
+      key: ev.currentTarget.getAttribute("urlkey"),
+      url: this.props.urls[ev.currentTarget.getAttribute("urlkey")],
+    });
+  }
+  render() {
+    return (
+      <React.Fragment>
+        <MaterialUI.AppBar position="fixed">
+          <MaterialUI.Toolbar>
+            <MaterialUI.IconButton
+              edge="start"
+              onClick={this.openDrawer}
+              color="secondary"
+            >
+              {helpers.createIcon("\ue5d2")}
+            </MaterialUI.IconButton>
+            <MaterialUI.Typography
+              style={{ flexGrow: 1 }}
+            ></MaterialUI.Typography>
+            <MaterialUI.IconButton
+              edge="end"
+              onClick={(ev) => {
+                this.setState({
+                  menuAnchorEl: ev.currentTarget,
+                });
+              }}
+              color="secondary"
+            >
+              <MaterialUI.Avatar
+                alt="test"
+                src={Globals.user.Picture}
+                style={{
+                  width: "32px",
+                  height: "32px",
+                  border: "1px solid #FDE2B5",
+                }}
+              />
+            </MaterialUI.IconButton>
+            <MaterialUI.Menu
+              anchorEl={this.state.menuAnchorEl}
+              anchorOrigin={{
+                vertical: "top",
+                horizontal: "right",
+              }}
+              transformOrigin={{
+                vertical: "top",
+                horizontal: "right",
+              }}
+              onClose={(_) => {
+                this.setState({ menuAnchorEl: null });
+              }}
+              open={!!this.state.menuAnchorEl}
+            >
+              <MaterialUI.MenuItem
+                key="stats"
+                onClick={(_) => {
+                  this.setState({
+                    menuAnchorEl: null,
+                    statsDialogOpen: true,
+                  });
+                }}
+              >
+                Player stats
+              </MaterialUI.MenuItem>
+
+              <MaterialUI.MenuItem key="logout" onClick={helpers.logout}>
+                Logout
+              </MaterialUI.MenuItem>
+            </MaterialUI.Menu>
+          </MaterialUI.Toolbar>
+        </MaterialUI.AppBar>
+        <div style={{ marginTop: "60px" }}>{this.renderActivity()}</div>
+        <MaterialUI.Drawer open={this.state.drawerOpen}>
+          <MaterialUI.ClickAwayListener onClickAway={this.closeDrawer}>
+            <div onClick={this.closeDrawer}>
+              <MaterialUI.List component="nav">
+                <MaterialUI.ListItem
+                  style={{ padding: "24px 16px 8px 16px", height: "40px" }}
+                >
+                  <MaterialUI.ListItemText
+                    primary="My Diplicity"
+                    disableTypography
+                    className={helpers.scopedClass(`
+    color: rgba(40, 26, 26, 0.56);
+    min-height: auto;
+    min-width: auto;
+    font: 500 14px / 48px Cabin, Roboto, sans-serif;
+    margin: 0px 0px 2px;
+
+              	`)}
+                  />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.ListItem
+                  button
+                  onClick={(_) => {
+                    this.setActivity(Start, {
+                      urls: this.props.urls,
+                      findPrivateGame: this.findGameByID,
+                      findOpenGame: this.renderOpenGames,
+                      myStagingGames: this.renderMyStagingGames,
+                    });
+                  }}
+                >
+                  <MaterialUI.ListItemText primary="My games" />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.ListItem
+                  button
+                  onClick={(_) => {
+                    this.setState({ menuAnchorEl: null });
+                    this.settingsDialog.setState({
+                      open: true,
+                    });
+                  }}
+                >
+                  <MaterialUI.ListItemText primary="Settings" />
+                </MaterialUI.ListItem>
+
+                {/* TODO: make sure these are in the "view more"
+                <MaterialUI.ListItem
+                  button
+                  urlkey="my-started-games"
+                  label="My started games"
+                  onClick={this.renderGameList}
+                >
+                  <MaterialUI.ListItemText primary="My started games" />
+                </MaterialUI.ListItem>
+                <MaterialUI.ListItem
+                  button
+                  urlkey="my-staging-games"
+                  label="My staging games"
+                  onClick={this.renderGameList}
+                >
+                  <MaterialUI.ListItemText primary="My staging games" />
+                </MaterialUI.ListItem>
+                <MaterialUI.ListItem
+                  button
+                  urlkey="my-finished-games"
+                  label="My finished games"
+                  onClick={this.renderGameList}
+                >
+                  <MaterialUI.ListItemText primary="My finished games" />
+                </MaterialUI.ListItem>
+            */}
+                <MaterialUI.Divider />
+
+                <MaterialUI.ListItem
+                  style={{ padding: "24px 16px 8px 16px", height: "40px" }}
+                >
+                  <MaterialUI.ListItemText
+                    primary="Public games"
+                    disableTypography
+                    className={helpers.scopedClass(`
+    color: rgba(40, 26, 26, 0.56);
+    min-height: auto;
+    min-width: auto;
+    font: 500 14px / 48px Cabin, Roboto, sans-serif;
+    margin: 0px 0px 2px;
+
+              	`)}
+                  />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.ListItem
+                  button
+                  urlkey="open-games"
+                  label="Open games"
+                  onClick={this.renderGameList}
+                >
+                  <MaterialUI.ListItemText primary="Open games" />
+                </MaterialUI.ListItem>
+                <MaterialUI.ListItem
+                  style={{ padding: "4px 16px" }}
+                  button
+                  urlkey="started-games"
+                  label="Started games"
+                  onClick={this.renderGameList}
+                >
+                  <MaterialUI.ListItemText primary="Started games" />
+                </MaterialUI.ListItem>
+                <MaterialUI.ListItem
+                  button
+                  urlkey="finished-games"
+                  label="Finished games"
+                  onClick={this.renderGameList}
+                >
+                  <MaterialUI.ListItemText primary="Finished games" />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.Divider />
+                <MaterialUI.ListItem
+                  style={{ padding: "24px 16px 8px 16px", height: "40px" }}
+                >
+                  <MaterialUI.ListItemText
+                    primary="Community"
+                    disableTypography
+                    className={helpers.scopedClass(`
+    color: rgba(40, 26, 26, 0.56);
+    min-height: auto;
+    min-width: auto;
+    font: 500 14px / 48px Cabin, Roboto, sans-serif;
+    margin: 0px 0px 2px;
+
+              	`)}
+                  />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.ListItem
+                  button
+                  onClick={(_) => {
+                    open("https://discord.gg/bu3JxYc");
+                  }}
+                >
+                  <MaterialUI.ListItemText primary="Chat" />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.ListItem
+                  style={{ padding: "4px 16px" }}
+                  button
+                  onClick={(_) => {
+                    open(
+                      "https://groups.google.com/forum/#!forum/diplicity-talk"
+                    );
+                  }}
+                >
+                  <MaterialUI.ListItemText primary="Forum" />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.ListItem
+                  button
+                  onClick={(_) => {
+                    open("https://sites.google.com/corp/view/diplicity");
+                  }}
+                >
+                  <MaterialUI.ListItemText primary="Help" />
+                </MaterialUI.ListItem>
+
+                <MaterialUI.Divider />
+
+                {/* 
+                <MaterialUI.ListItem
+                  button
+                  onClick={(_) => {
+                    open("https://github.com/zond/dipact");
+                  }}
+                >
+
+                  <MaterialUI.ListItemText primary="Github source code" />
+                }
+                </MaterialUI.ListItem>
+
+            */}
+              </MaterialUI.List>
+              <div
+                style={{ width: "calc(100% - 16px)", display: "Flex", justifyContent: "space-around", padding: "0px 8px" }}
+              >
+                <div id="github" style={{padding: "8px"}} 
+                                  onClick={(_) => {
+                    open("https://github.com/zond/dipact");
+                  }}>
+                  <MaterialUI.SvgIcon>
+                    <path
+                      fill="#281A1A"
+                      d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                    />
+                  </MaterialUI.SvgIcon>
+                </div>
+                <div id="errorlog"  style={{padding: "8px"}}
+                onClick={(_) => {
+                    this.closeDrawer;
+                    this.errorsDialog.setState({ open: true });
+                  }}>
+                {helpers.createIcon("\ue868")}</div>
+              </div>
+            </div>
+          </MaterialUI.ClickAwayListener>
+        </MaterialUI.Drawer>
+        <FindGameDialog
+          parentCB={(c) => {
+            this.findGameDialog = c;
+          }}
+          key="find-game-dialog"
+        />
+        <SettingsDialog
+          key="settings-dialog"
+          parentCB={(c) => {
+            this.settingsDialog = c;
+          }}
+        />
+        <ErrorsDialog
+          key="errors-dialog"
+          parentCB={(c) => {
+            this.errorsDialog = c;
+          }}
+        />
+        {this.state.statsDialogOpen ? (
+          <StatsDialog
+            open={this.state.statsDialogOpen}
+            user={Globals.user}
+            onClose={(_) => {
+              this.setState({ statsDialogOpen: false });
+            }}
+          />
+        ) : (
+          ""
+        )}
+      </React.Fragment>
+    );
+  }
 }

--- a/resources/js/main_menu.js
+++ b/resources/js/main_menu.js
@@ -17,7 +17,7 @@ export default class MainMenu extends ActivityContainer {
 		this.renderGameList = this.renderGameList.bind(this);
 		this.findGameByID = this.findGameByID.bind(this);
 		this.renderOpenGames = this.renderOpenGames.bind(this);
-		this.renderMyStagingGames = this.renderMyStagingGames.bind(this);
+		this.renderMyFinishedGames = this.renderMyFinishedGames.bind(this);
 		this.state = {
 			drawerOpen: false,
 			activity: Start,
@@ -26,7 +26,7 @@ export default class MainMenu extends ActivityContainer {
 				urls: this.props.urls,
 				findPrivateGame: this.findGameByID,
 				findOpenGame: this.renderOpenGames,
-				myStagingGames: this.renderMyStagingGames
+				renderMyFinishedGames: this.renderMyFinishedGames
 			}
 		};
 		this.findGameDialog = null;
@@ -53,7 +53,8 @@ export default class MainMenu extends ActivityContainer {
 									urls: this.props.urls,
 									findPrivateGame: this.findGameByID,
 									findOpenGame: this.renderOpenGames,
-									myStagingGames: this.renderMyStagingGames
+									renderMyFinishedGames: this
+										.renderMyFinishedGames
 								});
 							}
 						};
@@ -112,11 +113,11 @@ export default class MainMenu extends ActivityContainer {
 	closeDrawer() {
 		this.setState({ drawerOpen: false });
 	}
-	renderMyStagingGames() {
+	renderMyFinishedGames() {
 		this.setActivity(GameList, {
-			label: "My staging games",
-			key: "my-staging-games",
-			url: this.props.urls["my-staging-games"]
+			label: "My finished games",
+			key: "my-finished-games",
+			url: this.props.urls["my-finished-games"]
 		});
 	}
 	renderOpenGames() {
@@ -237,8 +238,8 @@ export default class MainMenu extends ActivityContainer {
 											urls: this.props.urls,
 											findPrivateGame: this.findGameByID,
 											findOpenGame: this.renderOpenGames,
-											myStagingGames: this
-												.renderMyStagingGames
+											renderMyFinishedGames: this
+												.renderMyFinishedGames
 										});
 									}}
 								>

--- a/resources/js/main_menu.js
+++ b/resources/js/main_menu.js
@@ -205,11 +205,11 @@ export default class MainMenu extends ActivityContainer {
 					</MaterialUI.Toolbar>
 				</MaterialUI.AppBar>
 				<div style={{ marginTop: "60px" }}>{this.renderActivity()}</div>
-				<MaterialUI.Drawer open={this.state.drawerOpen}>
+				<MaterialUI.Drawer open={this.state.drawerOpen} >
 					<MaterialUI.ClickAwayListener
 						onClickAway={this.closeDrawer}
 					>
-						<div onClick={this.closeDrawer}>
+						<div onClick={this.closeDrawer} style={{width:"220px"}}>
 							<MaterialUI.List component="nav">
 								<MaterialUI.ListItem
 									style={{

--- a/resources/js/start.js
+++ b/resources/js/start.js
@@ -8,6 +8,7 @@ export default class Start extends React.Component {
 		super(props);
 		this.state = { newGameFormOpen: false };
 		this.createGameDialog = null;
+	
 	}
 	componentDidMount() {
 		gtag("set", { "page_title": "Start", "page_location": location.href });
@@ -25,6 +26,7 @@ export default class Start extends React.Component {
 						<MaterialUI.List>
 							<li key="started">
 								<ul style={{ paddingInlineStart: 0 }}>
+									<div style={{display:"flex", justifyContent:"space-between", paddingRight: "8px", }}>
 									<MaterialUI.ListSubheader
 										style={{
 											backgroundColor: "white",
@@ -36,6 +38,10 @@ export default class Start extends React.Component {
 									>
 										My ongoing games
 									</MaterialUI.ListSubheader>
+									<MaterialUI.Button>
+									View all
+									</MaterialUI.Button>
+									</div>
 									<MaterialUI.ListItem
 										style={{
 											padding: "0px 16px 4px 16px",
@@ -57,6 +63,7 @@ export default class Start extends React.Component {
 							</li>
 							<li key="staging">
 								<ul style={{ paddingInlineStart: 0 }}>
+																		<div style={{display:"flex", justifyContent:"space-between", paddingRight: "8px", }}>
 									<MaterialUI.ListSubheader
 										style={{
 											backgroundColor: "white",
@@ -68,6 +75,11 @@ export default class Start extends React.Component {
 									>
 										My forming games
 									</MaterialUI.ListSubheader>
+									<MaterialUI.Button>
+									View all
+									</MaterialUI.Button>
+									</div>
+
 									<MaterialUI.ListItem
 										style={{
 											padding: "0px 16px 4px 16px"
@@ -88,6 +100,7 @@ export default class Start extends React.Component {
 							</li>
 							<li key="finished">
 								<ul style={{ paddingInlineStart: 0 }}>
+																	<div style={{display:"flex", justifyContent:"space-between", paddingRight: "8px", }}>
 									<MaterialUI.ListSubheader
 										style={{
 											backgroundColor: "white",
@@ -99,6 +112,11 @@ export default class Start extends React.Component {
 									>
 										My finished games
 									</MaterialUI.ListSubheader>
+									<MaterialUI.Button>
+									View all
+									</MaterialUI.Button>
+									</div>
+
 									<MaterialUI.ListItem
 										style={{
 											padding: "0px 16px 4px 16px"

--- a/resources/js/start.js
+++ b/resources/js/start.js
@@ -8,10 +8,12 @@ export default class Start extends React.Component {
 		super(props);
 		this.state = { newGameFormOpen: false };
 		this.createGameDialog = null;
-	
+		this.myStagingGamesList = null;
+		this.myStartedGamesList = null;
+		this.myFinishedGamesList = null;
 	}
 	componentDidMount() {
-		gtag("set", { "page_title": "Start", "page_location": location.href });
+		gtag("set", { page_title: "Start", page_location: location.href });
 		gtag("event", "page_view");
 	}
 	render() {
@@ -24,23 +26,26 @@ export default class Start extends React.Component {
 						)}
 					>
 						<MaterialUI.List>
-							<li key="started">
+							<li key="started" id="my-started-container">
 								<ul style={{ paddingInlineStart: 0 }}>
-									<div style={{display:"flex", justifyContent:"space-between", paddingRight: "8px", }}>
-									<MaterialUI.ListSubheader
+									<div
 										style={{
-											backgroundColor: "white",
-											zIndex: "2",
-											marginBottom: "2px",
-											height: "44px",
-											color: "rgba(40, 26, 26, 0.56)"
+											display: "flex",
+											justifyContent: "space-between",
+											paddingRight: "8px"
 										}}
 									>
-										My ongoing games
-									</MaterialUI.ListSubheader>
-									<MaterialUI.Button>
-									View all
-									</MaterialUI.Button>
+										<MaterialUI.ListSubheader
+											style={{
+												backgroundColor: "white",
+												zIndex: "2",
+												marginBottom: "2px",
+												height: "44px",
+												color: "rgba(40, 26, 26, 0.56)"
+											}}
+										>
+											My ongoing games
+										</MaterialUI.ListSubheader>
 									</div>
 									<MaterialUI.ListItem
 										style={{
@@ -49,35 +54,54 @@ export default class Start extends React.Component {
 										}}
 									>
 										<GameList
+											limit={128}
 											contained={true}
 											url={
 												this.props.urls[
 													"my-started-games"
 												]
 											}
-											limit={8}
-											skipMore={true}
+											onPhaseMessage={_ => {
+												this.myStartedGamesList.reload();
+												this.myFinishedGamesList.reload();
+											}}
+											parentCB={c => {
+												this.myStartedGamesList = c;
+											}}
+											onFilled={_ => {
+												document.getElementById(
+													"my-started-container"
+												).style.display = "block";
+											}}
+											onEmpty={_ => {
+												document.getElementById(
+													"my-started-container"
+												).style.display = "none";
+											}}
 										/>
 									</MaterialUI.ListItem>
 								</ul>
 							</li>
-							<li key="staging">
+							<li key="staging" id="my-staging-container">
 								<ul style={{ paddingInlineStart: 0 }}>
-																		<div style={{display:"flex", justifyContent:"space-between", paddingRight: "8px", }}>
-									<MaterialUI.ListSubheader
+									<div
 										style={{
-											backgroundColor: "white",
-											zIndex: "2",
-											marginBottom: "2px",
-											height: "44px",
-											color: "rgba(40, 26, 26, 0.56)"
+											display: "flex",
+											justifyContent: "space-between",
+											paddingRight: "8px"
 										}}
 									>
-										My forming games
-									</MaterialUI.ListSubheader>
-									<MaterialUI.Button>
-									View all
-									</MaterialUI.Button>
+										<MaterialUI.ListSubheader
+											style={{
+												backgroundColor: "white",
+												zIndex: "2",
+												marginBottom: "2px",
+												height: "44px",
+												color: "rgba(40, 26, 26, 0.56)"
+											}}
+										>
+											My forming games
+										</MaterialUI.ListSubheader>
 									</div>
 
 									<MaterialUI.ListItem
@@ -86,35 +110,62 @@ export default class Start extends React.Component {
 										}}
 									>
 										<GameList
+											limit={128}
 											contained={true}
+											onPhaseMessage={_ => {
+												this.myStartedGamesList.reload();
+												this.myStagingGamesList.reload();
+											}}
+											onFilled={_ => {
+												document.getElementById(
+													"my-staging-container"
+												).style.display = "block";
+											}}
+											withDetails={true}
+											onEmpty={_ => {
+												document.getElementById(
+													"my-staging-container"
+												).style.display = "none";
+											}}
+											parentCB={c => {
+												this.myStagingGamesList = c;
+											}}
 											url={
 												this.props.urls[
 													"my-staging-games"
 												]
 											}
-											limit={8}
-											skipMore={true}
 										/>
 									</MaterialUI.ListItem>
 								</ul>
 							</li>
-							<li key="finished">
+							<li key="finished" id="my-finished-container">
 								<ul style={{ paddingInlineStart: 0 }}>
-																	<div style={{display:"flex", justifyContent:"space-between", paddingRight: "8px", }}>
-									<MaterialUI.ListSubheader
+									<div
 										style={{
-											backgroundColor: "white",
-											zIndex: "2",
-											marginBottom: "2px",
-											height: "44px",
-											color: "rgba(40, 26, 26, 0.56)"
+											display: "flex",
+											justifyContent: "space-between",
+											paddingRight: "8px"
 										}}
 									>
-										My finished games
-									</MaterialUI.ListSubheader>
-									<MaterialUI.Button>
-									View all
-									</MaterialUI.Button>
+										<MaterialUI.ListSubheader
+											style={{
+												backgroundColor: "white",
+												zIndex: "2",
+												marginBottom: "2px",
+												height: "44px",
+												color: "rgba(40, 26, 26, 0.56)"
+											}}
+										>
+											My finished games
+										</MaterialUI.ListSubheader>
+										<MaterialUI.Button
+											onClick={
+												this.props.renderMyFinishedGames
+											}
+										>
+											View all
+										</MaterialUI.Button>
 									</div>
 
 									<MaterialUI.ListItem
@@ -124,13 +175,25 @@ export default class Start extends React.Component {
 									>
 										<GameList
 											contained={true}
+											parentCB={c => {
+												this.myFinishedGamesList = c;
+											}}
+											onFilled={_ => {
+												document.getElementById(
+													"my-finished-container"
+												).style.display = "block";
+											}}
+											onEmpty={_ => {
+												document.getElementById(
+													"my-finished-container"
+												).style.display = "none";
+											}}
 											url={
 												this.props.urls[
 													"my-finished-games"
 												]
 											}
 											limit={8}
-											skipMore={true}
 										/>
 									</MaterialUI.ListItem>
 								</ul>
@@ -326,7 +389,9 @@ export default class Start extends React.Component {
 					</React.Fragment>
 				)}
 				<CreateGameDialog
-					gameCreated={this.props.myStagingGames}
+					gameCreated={_ => {
+						this.myStagingGamesList.reload();
+					}}
 					parentCB={c => {
 						this.createGameDialog = c;
 					}}


### PR DESCRIPTION
Redid a lot of things. 

Need some help on:
1) The "VIEW ALL" buttons link to the pages the previous "my staging" etc linked to. However, since it's a different context, I can't get the this.SetActivity to work.
2) In the "My started"  and "My staging" screens, I've removed skipmore={true} and limit={8}. Please double check I didn't destroy anything.

3) Now that I upload, I think for the staging and playing, we should remove the VIEW ALL buttons (not necessary). Could you do this when you look at it (just remove the div surrounding the subtitleview)

4) For "Staging", we should by default show the "expandable'' version in Start.js - you don't really need to see the empty game for Staging games (Mustering will move to started anyway), but you want to see the details/players.

5) For "Finished" we don't change anything from now (except the working VIEW ALL button); by default you just go into the game (e.g. when just finished), view all shows you the detail screens (advanced feature). You can even go to "view all" if you have only 1 historical game.

6) Please make the WHOLE "My started" subtitle and list disappear when there is no game started. Same for "My staging" and "My finished". 