### PR TITLE
Add redirect server

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -26,8 +26,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "start-redirect-server": "node ./src/server.js"
+    "start-redirect-server": "node ./src/redirectServer.js"
   },
+  "proxy": "http://localhost:4000",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "chart.js": "^3.4.0",
+    "express": "^4.17.1",
     "firebase": "^8.7.0",
     "ga-gtag": "^1.1.0",
     "jquery": "^3.6.0",
@@ -24,7 +25,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start-redirect-server": "node ./src/server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/web-app/src/redirectServer.js
+++ b/web-app/src/redirectServer.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const app = express();
 
 const indexRouter = router.post('/', function(req, res, next) {
-    res.redirect('http://localhost:3002');  // <- need to get actual url of react app
+    res.redirect('http://localhost:3005');  // <- need to get actual url of react app
 });
 
 app.use('/', indexRouter);

--- a/web-app/src/redirectServer.js
+++ b/web-app/src/redirectServer.js
@@ -1,0 +1,15 @@
+const express = require('express');
+
+const port = process.env.PORT || 4000;
+const router = express.Router();
+const app = express();
+
+const indexRouter = router.post('/', function(req, res, next) {
+    res.redirect('http://localhost:3002');  // <- need to get actual url of react app
+});
+
+app.use('/', indexRouter);
+
+app.listen(port, () => {
+    console.log(`Listening at http://localhost:${port}`)
+});


### PR DESCRIPTION
Adds a tiny express server to handle post request from diplicity service and redirect to react app

To recreate this:
* change line 25 of `package.json` to `"start": "PORT=3005 react-scripts start"` to run it on a port you haven't used before.
* Run the react app `yarn start`
* Run the redirect server `start-redirect-server`
* Open the app in incognito and sign in. When you go through the approval page you should get redirected to the react app itself.

The implementation is a little messy. We need to have the react app url as an environment variable available to the redirect server