### PR TITLE
Add documentation for handling translations and convert translate keys to object

### DIFF
--- a/web-app/src/hooks/useCreateGame.ts
+++ b/web-app/src/hooks/useCreateGame.ts
@@ -90,13 +90,13 @@ const useCreateGame = (): IUseCreateGame => {
             .min(
               ((getUserStatsQuery.data.TrueSkill?.Rating || 0) -
                 0.01) as number,
-              tk.CreateGameMaxRatingInputErrorMessageLessThanUserRating
+              tk.createGame.maxRatingInput.errorMessage.lessThanUserRating
             ),
           minRating: yup
             .number()
             .max(
               getUserStatsQuery.data.TrueSkill?.Rating as number,
-              tk.CreateGameMinRatingInputErrorMessageMoreThanUserRating
+              tk.createGame.maxRatingInput.errorMessage.moreThanUserRating
             ),
         })
       );

--- a/web-app/src/hooks/useGameList.ts
+++ b/web-app/src/hooks/useGameList.ts
@@ -31,8 +31,8 @@ export const nationAllocationMap: { [key: number]: NationAllocation } = {
 };
 
 export const nationAllocationTranslations: { [key: string]: string } = {
-  [NationAllocation.Random]: tk.NationAllocationOptionsRandom,
-  [NationAllocation.Preference]: tk.NationAllocationOptionsPreference,
+  [NationAllocation.Random]: tk.nationAllocationOptions.random,
+  [NationAllocation.Preference]: tk.nationAllocationOptions.preference,
 }
 
 interface Player {

--- a/web-app/src/pages/CreateGame.tsx
+++ b/web-app/src/pages/CreateGame.tsx
@@ -163,7 +163,7 @@ const CreateGame = (): React.ReactElement => {
   const minEndAfterYearsValue = (selectedVariant?.Start?.Year || 0) + 1;
 
   return (
-    <GoBackNav title={t(tk.CreateGameTitle)}>
+    <GoBackNav title={t(tk.createGame.title)}>
       {isLoading ? (
         <Loading />
       ) : (
@@ -173,14 +173,14 @@ const CreateGame = (): React.ReactElement => {
               <div className={classes.nameInputContainer}>
                 <TextField
                   variant="standard"
-                  label={t(tk.CreateGameNameInputLabel)}
+                  label={t(tk.createGame.nameInput.label)}
                   name="name"
                   margin="dense"
                   value={values.name}
                   onChange={handleChange}
                 />
                 <IconButton
-                  title={t(tk.CreateGameRandomizeNameButtonTitle)}
+                  title={t(tk.createGame.randomizeGameNameButton.title)}
                   onClick={randomizeName}
                   size="large"
                 >
@@ -198,7 +198,7 @@ const CreateGame = (): React.ReactElement => {
                       onChange={handleChange}
                     />
                   }
-                  label={t(tk.CreateGamePrivateCheckboxLabel) as string}
+                  label={t(tk.createGame.privateCheckbox.label) as string}
                 />
                 <FormControlLabel
                   control={
@@ -209,15 +209,15 @@ const CreateGame = (): React.ReactElement => {
                       disabled={!values.privateGame}
                     />
                   }
-                  label={t(tk.CreateGameGameMasterCheckboxLabel) as string}
+                  label={t(tk.createGame.gameMasterCheckbox.label) as string}
                 />
                 {values.privateGame ? (
                   <FormHelperText>
-                    {t(tk.CreateGameGameMasterHelpTextDefault)}
+                    {t(tk.createGame.gameMasterCheckbox.helpText.default)}
                   </FormHelperText>
                 ) : (
                   <FormHelperText>
-                    {t(tk.CreateGameGameMasterHelpTextDisabled)}
+                    {t(tk.createGame.gameMasterCheckbox.helpText.disabled)}
                   </FormHelperText>
                 )}
               </FormGroup>
@@ -230,7 +230,7 @@ const CreateGame = (): React.ReactElement => {
                     className={classes.variantSelect}
                   >
                     <InputLabel htmlFor="variant-input-label">
-                      {t(tk.CreateGameVariantSelectLabel)}
+                      {t(tk.createGame.variantSelect.label)}
                     </InputLabel>
                     <Select
                       id="variant-input-label"
@@ -248,7 +248,7 @@ const CreateGame = (): React.ReactElement => {
                           value={variant.Name}
                           title={variant.Name}
                         >
-                          {t(tk.CreateGameVariantSelectOptionLabel, {
+                          {t(tk.createGame.variantSelect.optionLabel, {
                             name: variant.Name,
                             numPlayers: variant.Nations.length,
                           })}
@@ -300,7 +300,7 @@ const CreateGame = (): React.ReactElement => {
             </section>
             <section>
               <Typography variant="caption">
-                {t(tk.CreateGameNationAllocationSectionLabel)}
+                {t(tk.createGame.nationAllocationSection.label)}
               </Typography>
 
               <RadioGroup
@@ -337,7 +337,7 @@ const CreateGame = (): React.ReactElement => {
               <Box display="flex">
                 <TextField
                   name="phaseLengthMultiplier"
-                  label={t(tk.CreateGamePhaseLengthMultiplierInputLabel)}
+                  label={t(tk.createGame.phaseLengthMultiplierInput.label)}
                   type="number"
                   inputProps={{ min: 1 }}
                   value={values.phaseLengthMultiplier}
@@ -345,7 +345,7 @@ const CreateGame = (): React.ReactElement => {
                   variant="standard"
                 />
                 <InputLabel id="phase-length-unit-input-label">
-                  {t(tk.CreateGamePhaseLengthUnitSelectLabel)}
+                  {t(tk.createGame.phaseLengthUnitSelect.label)}
                 </InputLabel>
                 <Select
                   name="phaseLengthUnit"
@@ -356,18 +356,18 @@ const CreateGame = (): React.ReactElement => {
                 >
                   <MenuItem key={1} value={1}>
                     {singularPhaseLength
-                      ? t(tk.DurationsMinuteSingular)
-                      : t(tk.DurationsMinutePlural)}
+                      ? t(tk.durations.minute.singular)
+                      : t(tk.durations.minute.plural)}
                   </MenuItem>
                   <MenuItem key={60} value={60}>
                     {singularPhaseLength
-                      ? t(tk.DurationsHourSingular)
-                      : t(tk.DurationsHourPlural)}
+                      ? t(tk.durations.hour.singular)
+                      : t(tk.durations.hour.plural)}
                   </MenuItem>
                   <MenuItem key={60 * 24} value={60 * 24}>
                     {singularPhaseLength
-                      ? t(tk.DurationsDaySingular)
-                      : t(tk.DurationsDayPlural)}
+                      ? t(tk.durations.day.singular)
+                      : t(tk.durations.day.plural)}
                   </MenuItem>
                 </Select>
               </Box>
@@ -673,7 +673,7 @@ const CreateGame = (): React.ReactElement => {
                 variant="contained"
                 disabled={submitDisabled}
               >
-                {t(tk.CreateGameSubmitButtonLabel)}
+                {t(tk.createGame.submitButton.label)}
               </Button>
             </div>
           </form>

--- a/web-app/src/pages/__tests__/CreateGame.test.tsx
+++ b/web-app/src/pages/__tests__/CreateGame.test.tsx
@@ -129,13 +129,13 @@ describe("Create game functional tests", () => {
 
   test("Page load causes ga event", async () => {
     await renderPage(createGameUrl);
-    await waitFor(() => screen.getByLabelText(tk.CreateGameNameInputLabel));
+    await waitFor(() => screen.getByLabelText(tk.createGame.nameInput.label));
     pageLoadGAEventHappens(gaSetSpy, gaEventSpy, "CreateGame");
   });
 
   test("Hits endpoints correctly", async () => {
     await renderPage(createGameUrl);
-    await waitFor(() => screen.getByLabelText(tk.CreateGameNameInputLabel));
+    await waitFor(() => screen.getByLabelText(tk.createGame.nameInput.label));
     const calls = fetchSpy.mock.calls.map((call) => call[0] as Request);
     expect(
       calls.find((call) => call.url === `${diplicityServiceURL}`)
@@ -157,16 +157,16 @@ describe("Create game functional tests", () => {
 
   test("Name input has random name by default", async () => {
     await renderPage(createGameUrl);
-    await waitFor(() => screen.getByLabelText(tk.CreateGameNameInputLabel));
+    await waitFor(() => screen.getByLabelText(tk.createGame.nameInput.label));
     await waitFor(() => screen.getByDisplayValue(randomGameName));
   });
 
   test("Clicking randomize button creates new random name", async () => {
     await renderPage(createGameUrl);
-    await waitFor(() => screen.getByLabelText(tk.CreateGameNameInputLabel));
+    await waitFor(() => screen.getByLabelText(tk.createGame.nameInput.label));
     await waitFor(() => screen.getByDisplayValue(randomGameName));
-    const input = screen.getByLabelText(tk.CreateGameNameInputLabel);
-    const button = screen.getByTitle(tk.CreateGameRandomizeNameButtonTitle);
+    const input = screen.getByLabelText(tk.createGame.nameInput.label);
+    const button = screen.getByTitle(tk.createGame.randomizeGameNameButton.title);
     fireEvent.change(input, { target: { value: "Some string" } });
     await waitFor(() => screen.getByDisplayValue("Some string"));
     fireEvent.click(button);
@@ -176,7 +176,7 @@ describe("Create game functional tests", () => {
   test("Private unchecked by default", async () => {
     await renderPage(createGameUrl);
     const checkbox = (await waitFor(() =>
-      screen.getByLabelText(tk.CreateGamePrivateCheckboxLabel)
+      screen.getByLabelText(tk.createGame.privateCheckbox.label)
     )) as HTMLInputElement;
     expect(checkbox.checked).toBe(false);
   });
@@ -184,18 +184,18 @@ describe("Create game functional tests", () => {
   test("Game master help text when not private", async () => {
     await renderPage(createGameUrl);
     await waitFor(() =>
-      screen.getByText(tk.CreateGameGameMasterHelpTextDisabled)
+      screen.getByText(tk.createGame.gameMasterCheckbox.helpText.disabled)
     );
   });
 
   test("Game master help text when private", async () => {
     await renderPage(createGameUrl);
     const checkbox = (await waitFor(() =>
-      screen.getByLabelText(tk.CreateGamePrivateCheckboxLabel)
+      screen.getByLabelText(tk.createGame.privateCheckbox.label)
     )) as HTMLInputElement;
     fireEvent.click(checkbox);
     await waitFor(() =>
-      screen.getByText(tk.CreateGameGameMasterHelpTextDefault)
+      screen.getByText(tk.createGame.gameMasterCheckbox.helpText.default)
     );
   });
 
@@ -212,7 +212,7 @@ describe("Create game functional tests", () => {
   test("Variant select shows different variant", async () => {
     await renderPage(createGameUrl);
     const select = await waitFor(() =>
-      screen.getByLabelText(tk.CreateGameVariantSelectLabel)
+      screen.getByLabelText(tk.createGame.variantSelect.label)
     );
     fireEvent.change(select, { target: { value: "Twenty Twenty" } });
     await waitFor(() => screen.getByText("TTTPPP"));
@@ -221,7 +221,7 @@ describe("Create game functional tests", () => {
   test("Changing variant select shows loading spinner", async () => {
     await renderPage(createGameUrl);
     const select = await waitFor(() =>
-      screen.getByLabelText(tk.CreateGameVariantSelectLabel)
+      screen.getByLabelText(tk.createGame.variantSelect.label)
     );
     fireEvent.change(select, { target: { value: "Twenty Twenty" } });
     await waitFor(() => screen.getByRole("progressbar"));
@@ -244,17 +244,17 @@ describe("Create game functional tests", () => {
   test("Nation selection options appear", async () => {
     await renderPage(createGameUrl);
     await waitFor(() =>
-      screen.getByLabelText(tk.NationAllocationOptionsRandom)
+      screen.getByLabelText(tk.nationAllocationOptions.random)
     );
     await waitFor(() =>
-      screen.getByLabelText(tk.NationAllocationOptionsPreference)
+      screen.getByLabelText(tk.nationAllocationOptions.preference)
     );
   });
 
-  test("Nation selection random is defualt", async () => {
+  test("Nation selection random is default", async () => {
     await renderPage(createGameUrl);
     const randomOption = await waitFor(() =>
-      screen.getByLabelText(tk.NationAllocationOptionsRandom)
+      screen.getByLabelText(tk.nationAllocationOptions.random)
     );
     expect(randomOption).toHaveAttribute("checked");
   });
@@ -262,7 +262,7 @@ describe("Create game functional tests", () => {
   test("Game length value defaults to 1", async () => {
     await renderPage(createGameUrl);
     const phaseLengthMultiplierInput = (await waitFor(() =>
-      screen.getByLabelText(tk.CreateGamePhaseLengthMultiplierInputLabel)
+      screen.getByLabelText(tk.createGame.phaseLengthMultiplierInput.label)
     )) as HTMLInputElement;
     expect(phaseLengthMultiplierInput.value).toBe("1");
   });

--- a/web-app/src/translations/README.md
+++ b/web-app/src/translations/README.md
@@ -1,0 +1,54 @@
+# Translations
+
+## Overview
+
+We need to maintain translation strings for all user facing copy in the application.
+
+This includes text, labels, html element titles, tooltips, etc.
+
+### Implementation
+
+This section gives an overview on how translations are implemented in this project. For more detailed information, see https://react.i18next.com/
+
+#### Creating translations
+
+For every user facing string in the application we add an entry to the `translateKeys` object in `./translateKeys.ts`. This is the name of a translation string.
+
+By representing the keys using an object we can minimize issues with typos and keep our test code and rendering code dry.
+
+For every language that we support we create a json file inside `/translations/`. The file should be called `common.json` and live inside a sub-directory named after the language being translated, e.g. `/translations/en/common.json`.
+
+The json file must include a translation for each key in `translateKeys`. **Note** the structure of the json file has to match the structure of the translate key with dots (`.`) used to create hierarchy. See current implementation for guidance or consult the docs.
+
+Translate string which include variables need to be formatted using curly braces as follows:
+```
+"error-message": {
+    "more-than-user-rating": "Can't be higher than your own rating ({{ rating }})"
+}
+```
+
+To add a new language all we need to do is create a new translations file (copy the english translations file) and replace all the translation strings appropriately.
+
+#### Using translations in code
+
+The `CreateGame` component is a good example of how translations strings can be used in code.
+
+We can import `translateKeys` using `tk` for convenience as follows:
+```
+import tk from "../translations/translateKeys";
+```
+
+A component which uses translations needs to fetch the `t` function as follows:
+```
+const { t } = useTranslation("common");
+```
+
+To get the translated string for the current language we pass the translate key to the `t` function:
+```
+<span>t(tk.CreateGameRandomizeNameButtonTitle)</span>
+```
+
+If the translation string has variables we can pass variables to `t` as follows:
+```
+t(tk.CreateGameVariantSelectOptionLabel, { name: variant.Name, numPlayers: variant.Nations.length })
+```

--- a/web-app/src/translations/translateKeys.ts
+++ b/web-app/src/translations/translateKeys.ts
@@ -1,27 +1,65 @@
-enum TranslateKeys {
-  CreateGameTitle = "create-game.title",
-  CreateGameNameInputLabel = "create-game.name-input.label",
-  CreateGamePrivateCheckboxLabel = "create-game.private-checkbox.label",
-  CreateGameGameMasterCheckboxLabel = "create-game.game-master-checkbox.label",
-  CreateGameGameMasterHelpTextDefault = "create-game.game-master-checkbox.help-text.default",
-  CreateGameGameMasterHelpTextDisabled = "create-game.game-master-checkbox.help-text.disabled",
-  CreateGameRandomizeNameButtonTitle = "create-game.randomize-name-button.title",
-  CreateGameMaxRatingInputErrorMessageLessThanUserRating = "create-game.max-rating-input.error-message.less-than-user-rating",
-  CreateGameMinRatingInputErrorMessageMoreThanUserRating = "create-game.min-rating-input.error-message.more-than-user-rating",
-  CreateGameVariantSelectLabel = "create-game.variant-select.label",
-  CreateGameVariantSelectOptionLabel = "create-game.variant-select.option-label",
-  CreateGameSubmitButtonLabel = "create-game.submit-button.label",
-  CreateGameNationAllocationSectionLabel = "create-game.nation-allocation-section.label",
-  CreateGamePhaseLengthMultiplierInputLabel =  "create-game.phase-length-multiplier-input.label",
-  CreateGamePhaseLengthUnitSelectLabel =  "create-game.phase-length-unit-select.label",
-  NationAllocationOptionsRandom = "nation-allocation-options.random",
-  NationAllocationOptionsPreference = "nation-allocation-options.preference",
-  DurationsMinuteSingular = "durations.minute.singular",
-  DurationsMinutePlural = "durations.minute.plural",
-  DurationsHourSingular = "durations.hour.singular",
-  DurationsHourPlural = "durations.hour.plural",
-  DurationsDaySingular = "durations.day.singular",
-  DurationsDayPlural = "durations.day.plural",
-}
+const translateKeys = {
+  createGame: {
+    title: "create-game.title",
+    nameInput: {
+      label: "create-game.name-input.label",
+    },
+    privateCheckbox: {
+      label: "create-game.game-master-checkbox.label",
+    },
+    gameMasterCheckbox: {
+      label: "create-game.private-checkbox.label",
+      helpText: {
+        default: "create-game.private-checkbox.help-text.default",
+        disabled: "create-game.private-checkbox.help-text.disabled",
+      },
+    },
+    randomizeGameNameButton: {
+      title: "create-game.randomize-name-button.title",
+    },
+    maxRatingInput: {
+      errorMessage: {
+        lessThanUserRating:
+          "create-game.max-rating-input.error-message.less-than-user-rating",
+        moreThanUserRating:
+          "create-game.max-rating-input.error-message.more-than-user-rating",
+      },
+    },
+    variantSelect: {
+      label: "create-game.variant-select.label",
+      optionLabel: "create-game.variant-select.option-label",
+    },
+    submitButton: {
+      label: "create-game.submit-button.label",
+    },
+    nationAllocationSection: {
+      label: "create-game.nation-allocation-section.label",
+    },
+    phaseLengthMultiplierInput: {
+      label: "create-game.phase-length-multiplier-input.label",
+    },
+    phaseLengthUnitSelect: {
+      label: "create-game.phase-length-unit-select.label",
+    },
+  },
+  durations: {
+    minute: {
+      singular: "durations.minute.singular",
+      plural: "durations.minute.plural",
+    },
+    hour: {
+      singular: "durations.hour.singular",
+      plural: "durations.hour.plural",
+    },
+    day: {
+      singular: "durations.day.singular",
+      plural: "durations.day.plural",
+    },
+  },
+  nationAllocationOptions: {
+    random: "nation-allocation-options.random",
+    preference: "nation-allocation-options.preference",
+  }
+};
 
-export default TranslateKeys;
+export default translateKeys;


### PR DESCRIPTION
Adds a README file to `/translations/` to explain how translations work in the application.

Converts translate keys from an enum to an object. This improves readability and also makes autocompletion much more powerful.

Closes: https://github.com/zond/dipact/issues/372