### PR TITLE
Filter beta games

### DIFF
--- a/packages/native-app/src/screens/CreateGame.tsx
+++ b/packages/native-app/src/screens/CreateGame.tsx
@@ -161,7 +161,7 @@ const CreateGame = () => {
                     setFieldValue("variant", selected)
                   }
                 >
-                  {variants.map((variant) => (
+                  {variants.filter(variant => !variant.Name.includes('Beta')).map((variant) => (
                     <Picker.Item
                       label={t(tk.createGame.variantSelect.optionLabel, {
                         name: variant.Name,

--- a/packages/native-app/src/screens/CreateGame.tsx
+++ b/packages/native-app/src/screens/CreateGame.tsx
@@ -161,7 +161,8 @@ const CreateGame = () => {
                     setFieldValue("variant", selected)
                   }
                 >
-                  {variants.filter(variant => !variant.Name.includes('Beta')).map((variant) => (
+                  {values.privateGame ? (
+                    variants.filter(variant => !variant.Name.includes('Beta')).map((variant) => (
                     <Picker.Item
                       label={t(tk.createGame.variantSelect.optionLabel, {
                         name: variant.Name,
@@ -170,7 +171,17 @@ const CreateGame = () => {
                       value={variant.Name}
                       key={variant.Name}
                     />
-                  ))}
+                  ))) : (
+                    variants.map((variant) => (
+                    <Picker.Item
+                      label={t(tk.createGame.variantSelect.optionLabel, {
+                        name: variant.Name,
+                        numPlayers: variant.Nations.length,
+                      })}
+                      value={variant.Name}
+                      key={variant.Name}
+                    />
+                  )))}
                 </Picker>
                 {isFetchingVariantSVG ? (
                   <Loading />

--- a/packages/web-app/src/pages/CreateGame.tsx
+++ b/packages/web-app/src/pages/CreateGame.tsx
@@ -237,7 +237,7 @@ const CreateGame = (): React.ReactElement => {
                         }
                         native
                       >
-                        {variants.map((variant) => (
+                        {variants.filter(variant => !variant.Name.includes('Beta')).map((variant) => (
                           <option
                             aria-checked={selectedVariant === variant}
                             key={variant.Name}

--- a/packages/web-app/src/pages/CreateGame.tsx
+++ b/packages/web-app/src/pages/CreateGame.tsx
@@ -237,7 +237,7 @@ const CreateGame = (): React.ReactElement => {
                         }
                         native
                       >
-                        {variants.filter(variant => !variant.Name.includes('Beta')).map((variant) => (
+                        {values.privateGame ? ( variants.filter(variant => !variant.Name.includes('Class')).map((variant) => (
                           <option
                             aria-checked={selectedVariant === variant}
                             key={variant.Name}
@@ -249,7 +249,20 @@ const CreateGame = (): React.ReactElement => {
                               numPlayers: variant.Nations.length,
                             })}
                           </option>
-                        ))}
+                        ))) : (
+                        variants.map((variant) => (
+                          <option
+                            aria-checked={selectedVariant === variant}
+                            key={variant.Name}
+                            value={variant.Name}
+                            title={variant.Name}
+                          >
+                            {t(tk.createGame.variantSelect.optionLabel, {
+                              name: variant.Name,
+                              numPlayers: variant.Nations.length,
+                            })}
+                          </option>
+                        )))}
                       </Select>
                     </FormControl>
                     {isFetchingVariantSVG ? (


### PR DESCRIPTION
@johnpooch I've added this so that when games are PRIVATE we show the list of Beta games.

In the Beta game description there will be a disclaimer. 

I would like to move this into GAME MASTER ONLY, so that only GMs can host a Beta map (and more importantly - that there is always a GM involved in a Beta game managing the players). However, for now, I think we can pull this, right? Can you quickly double check?